### PR TITLE
Added User 생성 및 Project 개설 Post 작성 및 이전 로직 Bug Fix.

### DIFF
--- a/Project-Matching/gradle/wrapper/gradle-wrapper.properties
+++ b/Project-Matching/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Fri Jul 19 18:57:12 KST 2019
+#Wed Jul 17 16:57:25 KST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/Project-Matching/src/main/java/com/matching/AppRunner.java
+++ b/Project-Matching/src/main/java/com/matching/AppRunner.java
@@ -9,11 +9,9 @@ import com.matching.domain.key.ProjectTagKey;
 import com.matching.domain.key.UserProjectKey;
 import com.matching.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +20,7 @@ import java.util.stream.IntStream;
 import java.util.*;
 
 @Component
+@EnableConfigurationProperties
 public class AppRunner implements ApplicationRunner {
     private final String TEST_CONTENT = "1. 동해물과 백두산이 마르고 닳도록 \n" +
             "하느님이 보우하사 우리나라 만세\n" +

--- a/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
+++ b/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
@@ -16,10 +16,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import javax.servlet.Filter;
+import java.util.Arrays;
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -35,21 +37,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         filter.setEncoding("UTF-8");
         filter.setForceEncoding(true);
 
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedOrigin(CorsConfiguration.ALL);
-        configuration.addAllowedMethod(CorsConfiguration.ALL);
-        configuration.addAllowedHeader(CorsConfiguration.ALL);
-        UrlBasedCorsConfigurationSource source =
-                new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-
-        http.httpBasic()
-                .and()
-                    .cors()
+        http.cors().
+                and().
+                    httpBasic()
                 .and()
                     .csrf().disable()
                 .authorizeRequests()
-                    .antMatchers(HttpMethod.GET, "/api/projects").permitAll()
+                    .antMatchers(HttpMethod.GET, "/api/projects", "/api/userskills").permitAll()
+                    .antMatchers(HttpMethod.POST, "/api/register/**").permitAll()
                     .anyRequest().hasAuthority("USER")
                 .and()
                     .addFilter(new JwtAuthenticationFilter(authenticationManager(), getApplicationContext()))
@@ -62,6 +57,21 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .logoutSuccessUrl("/api/projects")
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin(CorsConfiguration.ALL);
+        configuration.addAllowedMethod(CorsConfiguration.ALL);
+        configuration.addAllowedHeader(CorsConfiguration.ALL);
+
+        configuration.setExposedHeaders(Arrays.asList("Access-Control-Allow-Headers", "Authorization, x-xsrf-token, Access-Control-Allow-Headers, Origin, Accept, X-Requested-With, " +
+                "Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/Project-Matching/src/main/java/com/matching/config/auth/SecurityConstants.java
+++ b/Project-Matching/src/main/java/com/matching/config/auth/SecurityConstants.java
@@ -14,9 +14,9 @@ public class SecurityConstants {
 
     public static final String TOKEN_TYPE = "JwtToken";
 
-    public static final String TOKEN_ISSUER = "secure-api";
+    public static final String TOKEN_ISSUER = "Perfect-Matching Server";
 
-    public static final String TOKEN_AUDIENCE = "secure-app";
+    public static final String TOKEN_AUDIENCE = "Perfect-Matching Client";
 
     private SecurityConstants() {
         throw new IllegalStateException("Cannot create instance of static util class");

--- a/Project-Matching/src/main/java/com/matching/config/handler/CustomLogoutSuccessHandler.java
+++ b/Project-Matching/src/main/java/com/matching/config/handler/CustomLogoutSuccessHandler.java
@@ -24,14 +24,8 @@ public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         String token = request.getHeader(SecurityConstants.TOKEN_HEADER);
-
         token = token.replaceAll("Bearer", "").trim();
 
-        if(jwtTokenRepository.findByToken(token) == null)
-            throw new InvalidTokenException("토큰이 유효하지 않습니다.");
-
-        JwtToken jwtToken = jwtTokenRepository.findByToken(token);
-        jwtToken.setStatus(false);
-        jwtTokenRepository.save(jwtToken);
+        jwtTokenRepository.save(JwtToken.builder().token(token).build());
     }
 }

--- a/Project-Matching/src/main/java/com/matching/controller/ProjectController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package com.matching.controller;
 
 import com.matching.domain.Project;
+import com.matching.domain.dto.ProjectDTO;
 import com.matching.domain.enums.LocationType;
 import com.matching.service.ProfileService;
 import com.matching.service.ProjectService;
@@ -16,9 +17,13 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import java.util.List;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
@@ -32,7 +37,7 @@ public class ProjectController {
     private ProjectService projectService;
 
     @GetMapping(value = "/projects", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> getProjectsJsonView(@PageableDefault(size = 4) Pageable pageable, HttpServletResponse response,
+    public ResponseEntity<?> getProjectsJsonView(@PageableDefault(size = 12) Pageable pageable, HttpServletResponse response,
                                                     @RequestParam(required = false) LocationType location,
                                                     @RequestParam(required = false) String position) {
 
@@ -120,4 +125,18 @@ public class ProjectController {
 
         return ResponseEntity.ok(resources);
     }
+
+    @PostMapping(value = "/project")
+    public ResponseEntity<?> postProject(@Valid @RequestBody ProjectDTO projectDTO, BindingResult result, @AuthenticationPrincipal User user, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/project");
+
+        if (result.hasErrors()) {
+            StringBuilder msg = projectService.validation(result);
+            return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        return projectService.postProject(projectDTO, user);
+    }
+
 }

--- a/Project-Matching/src/main/java/com/matching/controller/RegisterController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/RegisterController.java
@@ -1,0 +1,60 @@
+package com.matching.controller;
+
+import com.matching.domain.dto.UserDTO;
+import com.matching.service.RegisterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/register")
+public class RegisterController {
+
+    @Autowired
+    private RegisterService registerService;
+
+    @PostMapping
+    public ResponseEntity<?> postUser(@Valid @RequestBody UserDTO userDTO, BindingResult result, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/register");
+
+        if (result.hasErrors()) {
+            StringBuilder msg = registerService.validation(result);
+            return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
+        } else if(!userDTO.getPassword().equals(userDTO.getConfirmPassword())) {
+            return new ResponseEntity<>("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+        } else if(registerService.findUserNick(userDTO.getNickname()) != null) {
+            return new ResponseEntity<>("이미 사용중인 닉네임입니다.", HttpStatus.BAD_REQUEST);
+        } else if(registerService.findUserEmail(userDTO.getEmail()) != null) {
+            return new ResponseEntity<>("이미 사용중인 이메일입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        return registerService.postUser(userDTO);
+    }
+
+    @PostMapping("/nickcheck")
+    public ResponseEntity<?> nickCheck(@RequestBody String nick, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/register/nickcheck");;
+        return registerService.findUserNick(nick) != null ? new ResponseEntity<>("이미 사용중인 닉네임입니다.", HttpStatus.BAD_REQUEST)
+                : new ResponseEntity<>("사용가능한 멋진 닉네임입니다.", HttpStatus.OK);
+    }
+
+    @PostMapping("/emailcheck")
+    public ResponseEntity<?> emailCheck(@RequestBody String email, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/register/emailcheck");
+        return registerService.findUserEmail(email) != null ? new ResponseEntity<>("이미 사용중인 이메일입니다.", HttpStatus.BAD_REQUEST)
+                : new ResponseEntity<>("사용가능한 멋진 이메일입니다.", HttpStatus.OK);
+    }
+
+
+}

--- a/Project-Matching/src/main/java/com/matching/controller/TagController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/TagController.java
@@ -3,6 +3,7 @@ package com.matching.controller;
 import com.matching.service.TagService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,20 @@ public class TagController {
     @Autowired
     private TagService tagService;
 
+    @GetMapping(value = "/tags", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getTags(HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/tags");
+
+        if(tagService.findByTags())
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        Resources<?> resources = tagService.getTags(response);
+        resources.add(linkTo(methodOn(TagController.class).getTags(response)).withSelfRel());
+
+        return ResponseEntity.ok(resources);
+    }
+
     @GetMapping(value = "/tag/{idx}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> getTag(@PathVariable Long idx, HttpServletResponse response) {
         response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
@@ -34,6 +49,20 @@ public class TagController {
         Resource<?> resource = tagService.getTag(idx);
         resource.add(linkTo(methodOn(TagController.class).getTag(idx, response)).withSelfRel());
         return ResponseEntity.ok(resource);
+    }
+
+    @GetMapping(value = "/userskills", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getUserSkills(HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/userskills");
+
+        if(tagService.findByUserSkills())
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        Resources<?> resources = tagService.getUserSkills(response);
+        resources.add(linkTo(methodOn(TagController.class).getUserSkills(response)).withSelfRel());
+
+        return ResponseEntity.ok(resources);
     }
 
     @GetMapping(value = "/userskill/{idx}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -49,6 +78,20 @@ public class TagController {
         return ResponseEntity.ok(resource);
     }
 
+    @GetMapping(value = "/usedskills", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getUsedSkills(HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/usedskills");
+
+        if(tagService.findByUsedSkills())
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        Resources<?> resources = tagService.getUsedSkills(response);
+        resources.add(linkTo(methodOn(TagController.class).getUsedSkills(response)).withSelfRel());
+
+        return ResponseEntity.ok(resources);
+    }
+
     @GetMapping(value = "/usedskill/{idx}", produces =MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> getUsedSkill(@PathVariable Long idx, HttpServletResponse response) {
         response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
@@ -61,4 +104,5 @@ public class TagController {
         resource.add(linkTo(methodOn(TagController.class).getUsedSkill(idx, response)).withSelfRel());
         return ResponseEntity.ok(resource);
     }
+
 }

--- a/Project-Matching/src/main/java/com/matching/domain/JwtToken.java
+++ b/Project-Matching/src/main/java/com/matching/domain/JwtToken.java
@@ -22,33 +22,12 @@ public class JwtToken implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @Column(nullable = false, length = 350)
+    @Column(nullable = false, length = 500)
     private String token;
 
-    @Column(nullable = false)
-    private Boolean status;
-
-    @OneToOne(targetEntity = User.class, fetch = FetchType.EAGER)
-    @JoinColumn(nullable = false, name = "user_id")
-    private User user;
-
-    @Column(nullable = false)
-    private Date expiryDate;
-
     @Builder
-    public JwtToken(String token, Boolean status, User user) {
+    public JwtToken(String token) {
         this.token = token;
-        this.status = status;
-        this.user = user;
     }
 
-    public boolean isExpired() {
-        return new Date().after(expiryDate);
-    }
-
-    public void setExpiryDate(int minutes) {
-        Calendar now = Calendar.getInstance();
-        now.add(Calendar.MINUTE, minutes);
-        this.expiryDate = now.getTime();
-    }
 }

--- a/Project-Matching/src/main/java/com/matching/domain/Tag.java
+++ b/Project-Matching/src/main/java/com/matching/domain/Tag.java
@@ -1,6 +1,7 @@
 package com.matching.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,7 +17,7 @@ import java.util.Set;
 @Data
 @Table
 @NoArgsConstructor
-@EqualsAndHashCode(of = "idx")
+@EqualsAndHashCode(of = {"idx", "text"})
 @Relation(collectionRelation = "datas")
 public class Tag implements Serializable {
 
@@ -29,7 +30,7 @@ public class Tag implements Serializable {
     private String text;
 
     @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY)
-    @JsonBackReference
+    @JsonIgnore
     private Set<ProjectTag> projectTags = new HashSet<>();
 
     @Builder

--- a/Project-Matching/src/main/java/com/matching/domain/User.java
+++ b/Project-Matching/src/main/java/com/matching/domain/User.java
@@ -58,7 +58,7 @@ public class User implements Serializable {
     @Column(nullable = false)
     private LocalDateTime createdDate;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String profileImg;
 
     @Column(nullable = false, length = 500)

--- a/Project-Matching/src/main/java/com/matching/domain/UserProject.java
+++ b/Project-Matching/src/main/java/com/matching/domain/UserProject.java
@@ -39,7 +39,7 @@ public class UserProject implements Serializable {
     @Enumerated(EnumType.STRING)
     private PositionType position;
 
-    @Column(nullable = false, length = 400)
+    @Column(length = 400)
     private String simpleProfile;
 
     @Builder

--- a/Project-Matching/src/main/java/com/matching/domain/UserSkill.java
+++ b/Project-Matching/src/main/java/com/matching/domain/UserSkill.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
 @Data
 @Table
 @NoArgsConstructor
-@EqualsAndHashCode(of = "idx")
+@EqualsAndHashCode(of = {"idx", "text"})
 @Relation(collectionRelation = "datas")
 public class UserSkill implements Serializable  {
 

--- a/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
@@ -52,7 +52,7 @@ public class DoneProjectDTO {
 
     private String socialUrl;
 
-    private Set<UsedSkill> usedSkills = new HashSet<>();
+    private final Set<UsedSkill> usedSkills = new HashSet<>();
 
     public DoneProjectDTO(DoneProject doneProject) {
         this.doneProjectIdx = doneProject.getIdx();

--- a/Project-Matching/src/main/java/com/matching/domain/dto/ProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/ProjectDTO.java
@@ -1,6 +1,10 @@
 package com.matching.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.matching.domain.Project;
+import com.matching.domain.Tag;
+import com.matching.domain.enums.LocationType;
 import com.matching.domain.enums.PositionType;
 import com.matching.domain.enums.UserProjectStatus;
 import com.matching.repository.UserProjectRepository;
@@ -10,8 +14,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Data
 @Builder
@@ -30,11 +39,9 @@ public class ProjectDTO {
     @Length(max = 30, min = 1)
     private String leader;
 
-    @NotBlank
     @Length(max = 5000, min = 1)
     private String content;
 
-    @NotBlank
     @Length(max = 10, min = 1)
     private String status;
 
@@ -42,23 +49,24 @@ public class ProjectDTO {
     @Length(max = 255, min = 1)
     private String location;
 
-    @NotBlank
+    @NotNull
     private LocalDateTime createdDate;
 
     private LocalDateTime modifiedDate;
 
-    @NotBlank
+    @NotNull
     private Integer developerRecruits;
 
-    @NotBlank
+    @NotNull
     private Integer designerRecruits;
 
-    @NotBlank
+    @NotNull
     private Integer plannerRecruits;
 
-    @NotBlank
+    @NotNull
     private Integer marketerRecruits;
 
+    @NotNull
     private Integer etcRecruits;
 
     private Integer currentDeveloper;
@@ -77,6 +85,8 @@ public class ProjectDTO {
 
     @Length(max = 100, min = 1)
     private String socialUrl;
+
+    private Set<Tag> tags = new HashSet<>();
 
     public ProjectDTO(Project project, UserProjectRepository userProjectRepo) {
         this.projectIdx = project.getIdx();
@@ -100,6 +110,5 @@ public class ProjectDTO {
         this.currentPlanner = userProjectRepo.countByProjectAndPositionAndStatus(project, PositionType.PLANNER, UserProjectStatus.MATCHING);
         this.currentEtc = userProjectRepo.countByProjectAndPositionAndStatus(project, PositionType.ETC, UserProjectStatus.MATCHING);
         this.socialUrl = project.getSocialUrl();
-
     }
 }

--- a/Project-Matching/src/main/java/com/matching/domain/dto/UserDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/UserDTO.java
@@ -1,0 +1,58 @@
+package com.matching.domain.dto;
+
+import com.matching.domain.UserSkill;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import java.util.HashSet;
+import java.util.Set;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+
+    private Long userIdx;
+
+    @NotBlank(message = "이메일이 비어있습니다.")
+    @Email(message = "유효한 이메일이 아닙니다. 이메일 형식인지 확인해주시길 바랍니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Length(min = 8, max = 22, message = "비밀번호는 8~22 사이로 작성해주서야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,22}$", message = "비밀번호 구성을 올바르게 하십시오.")
+    private String password;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Length(min = 8, max = 22, message = "비밀번호는 8~22 사이로 작성해주서야 합니다. ")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,22}$", message = "비밀번호 구성을 올바르게 하십시오.")
+    private String confirmPassword;
+
+    @NotBlank(message = "닉네임이 비어있습니다.")
+    @Length(max = 30, min = 2, message = "닉네임은 2~30 사이로 설정하시길 바랍니다.")
+    private String nickname;
+
+    @Length(max = 100, message = "프로필 이미지 URL은 100자 내외로 작성해주시길 바랍니다.")
+    private String profileImag;
+
+    @NotBlank(message = "자기소개가 비어있습니다.")
+    @Length(max = 500, message = "자기소개는 500자 내외로 작성해주시길 바랍니다.")
+    private String description;
+
+    @NotNull(message = "투자 시간이 비어있습니다.")
+    private Integer investTime;
+
+    @Length(max = 100, message = "URL은 100자 내외로 입력해주시길 바랍니다.")
+    private String socialUrl;
+
+    private Set<UserSkill> userSkills = new HashSet<>();
+
+}

--- a/Project-Matching/src/main/java/com/matching/domain/enums/LocationType.java
+++ b/Project-Matching/src/main/java/com/matching/domain/enums/LocationType.java
@@ -1,10 +1,12 @@
 package com.matching.domain.enums;
 
 import lombok.Getter;
+import lombok.ToString;
 
 import java.util.Random;
 
 @Getter
+@ToString
 public enum LocationType {
 
     SEOUL("서울"),
@@ -30,5 +32,9 @@ public enum LocationType {
     public static LocationType getRandomLocationType() {
         Random random = new Random();
         return values()[random.nextInt(values().length)];
+    }
+
+    public static LocationType getLocation(int index) {
+        return values()[index];
     }
 }

--- a/Project-Matching/src/main/java/com/matching/domain/enums/PositionType.java
+++ b/Project-Matching/src/main/java/com/matching/domain/enums/PositionType.java
@@ -11,7 +11,8 @@ public enum PositionType {
     DESIGNER("디자이너"),
     MARKETER("마케터"),
     PLANNER("기획자"),
-    ETC("기타");
+    ETC("기타"),
+    LEADER("리더");
 
     private String position;
 

--- a/Project-Matching/src/main/java/com/matching/repository/TagRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/TagRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     Tag findByIdx(Long tagIdx);
+
+    Tag findByText(String text);
 }

--- a/Project-Matching/src/main/java/com/matching/repository/UserRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/UserRepository.java
@@ -7,4 +7,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     User findByIdx(long idx);
     User findByEmail(String email);
+    User findByNick(String nick);
 }

--- a/Project-Matching/src/main/java/com/matching/service/RegisterService.java
+++ b/Project-Matching/src/main/java/com/matching/service/RegisterService.java
@@ -1,0 +1,60 @@
+package com.matching.service;
+
+import com.matching.domain.User;
+import com.matching.domain.UserSkill;
+import com.matching.domain.dto.UserDTO;
+import com.matching.repository.UserRepository;
+import com.matching.repository.UserSkillRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class RegisterService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserSkillRepository userSkillRepository;
+
+    public StringBuilder validation(BindingResult bindingResult) {
+        List<ObjectError> list = bindingResult.getAllErrors();
+        StringBuilder msg = new StringBuilder();
+        for (ObjectError error : list)
+            msg.append(error.getDefaultMessage()).append("\n");
+        return msg;
+    }
+
+    public User findUserNick(String nick) {
+        return userRepository.findByNick(nick);
+    }
+
+    public User findUserEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    public ResponseEntity<?> postUser(UserDTO userDTO) {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        User user = User.builder().createdDate(LocalDateTime.now()).email(userDTO.getEmail()).nick(userDTO.getNickname()).
+                password(passwordEncoder.encode(userDTO.getPassword())).profileImg(userDTO.getProfileImag()).description(userDTO.getDescription()).
+                investTime(userDTO.getInvestTime()).socialUrl(userDTO.getSocialUrl()).build();
+        userRepository.save(user);
+
+        for(UserSkill userSkill : userDTO.getUserSkills()) {
+            if (userSkill.getText().length() > 255)
+                return new ResponseEntity<>("태그의 길이가 255자 이상입니다.", HttpStatus.BAD_REQUEST);
+            user.addUserSkill(userSkill);
+            userSkillRepository.save(userSkill);
+        }
+
+        return new ResponseEntity<>("{}", HttpStatus.CREATED);
+    }
+}

--- a/Project-Matching/src/main/java/com/matching/service/TagService.java
+++ b/Project-Matching/src/main/java/com/matching/service/TagService.java
@@ -1,5 +1,9 @@
 package com.matching.service;
 
+import com.matching.controller.TagController;
+import com.matching.domain.Tag;
+import com.matching.domain.UsedSkill;
+import com.matching.domain.UserSkill;
 import com.matching.repository.TagRepository;
 import com.matching.repository.UsedSkillRepository;
 import com.matching.repository.UserSkillRepository;
@@ -7,6 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @Service
 public class TagService {
@@ -20,12 +31,46 @@ public class TagService {
     @Autowired
     private UsedSkillRepository usedSkillRepository;
 
+    public boolean findByTags() {
+        return tagRepository.findAll() == null;
+    }
+
+    public Resources<?> getTags(HttpServletResponse response) {
+        List<Resource> resources = new ArrayList<>();
+        List<Tag> tags = tagRepository.findAll();
+
+        for(Tag tag : tags) {
+            Resource<?> resource = new Resource<>(tag);
+            resource.add(linkTo(methodOn(TagController.class).getTag(tag.getIdx(), response)).withSelfRel());
+            resources.add(resource);
+        }
+
+        return new Resources<>(resources);
+    }
+
     public boolean findByTag(Long idx) {
         return tagRepository.findByIdx(idx) == null;
     }
 
     public Resource<?> getTag(Long idx) {
         return new Resource<>(tagRepository.findByIdx(idx));
+    }
+
+    public boolean findByUserSkills() {
+        return userSkillRepository.findAll() == null;
+    }
+
+    public Resources<?> getUserSkills(HttpServletResponse response) {
+        List<Resource> resources = new ArrayList<>();
+        List<UserSkill> userSkills = userSkillRepository.findAll();
+
+        for(UserSkill userSkill : userSkills) {
+            Resource<?> resource = new Resource<>(userSkill);
+            resource.add(linkTo(methodOn(TagController.class).getUserSkill(userSkill.getIdx(), response)).withSelfRel());
+            resources.add(resource);
+        }
+
+        return new Resources<>(resources);
     }
 
     public boolean findByUserSkill(Long idx) {
@@ -36,6 +81,23 @@ public class TagService {
         return new Resource<>(userSkillRepository.findByIdx(idx));
     }
 
+    public boolean findByUsedSkills() {
+        return usedSkillRepository.findAll() == null;
+    }
+
+    public Resources<?> getUsedSkills(HttpServletResponse response) {
+        List<Resource> resourceList = new ArrayList<>();
+        List<UsedSkill> usedSkills = usedSkillRepository.findAll();
+
+        for(UsedSkill usedSkill : usedSkills) {
+            Resource<?> resource = new Resource<>(usedSkill);
+            resource.add(linkTo(methodOn(TagController.class).getUsedSkill(usedSkill.getIdx(), response)).withSelfRel());
+            resourceList.add(resource);
+        }
+
+        return new Resources<>(resourceList);
+    }
+
     public boolean findByUsedSkill(Long idx) {
         return usedSkillRepository.findByIdx(idx) == null;
     }
@@ -43,4 +105,5 @@ public class TagService {
     public Resource<?> getUsedSkill(Long idx) {
         return new Resource<>(usedSkillRepository.findByIdx(idx));
     }
+
 }

--- a/Project-Matching/src/test/java/com/matching/controller/CommentControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/CommentControllerTest.java
@@ -1,0 +1,85 @@
+package com.matching.controller;
+
+import com.matching.domain.Comment;
+import com.matching.domain.Project;
+import com.matching.domain.User;
+import com.matching.domain.enums.LocationType;
+import com.matching.domain.enums.ProjectStatus;
+import com.matching.repository.CommentRepository;
+import com.matching.repository.ProjectRepository;
+import com.matching.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CommentControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private Comment comment;
+
+    @Before
+    public void setMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+
+        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user) ;
+
+        Project project = Project.builder().leader(user).title("테스트 프로젝트").content("테스트 생성").summary("테스트 프로젝트")
+                .status(ProjectStatus.getRandomProjectStatus()).location(LocationType.getRandomLocationType())
+                .createdDate(LocalDateTime.now()).designerRecruits(1).developerRecruits(1).etcRecruits(1).marketerRecruits(1).plannerRecruits(1)
+                .socialUrl("https://github.com/testUser/testProject").build();
+
+        projectRepository.save(project);
+
+
+        comment = Comment.builder().project(project).writer(user).content("테스트 댓글").createdDate(LocalDateTime.now())
+                .build();
+
+        commentRepository.save(comment);
+    }
+
+    @Test
+    public void getCommentTest() throws Exception {
+        mockMvc.perform(get("/api/project/" + comment.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/project/" + comment.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/Project-Matching/src/test/java/com/matching/controller/DoneProjectControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/DoneProjectControllerTest.java
@@ -1,0 +1,81 @@
+package com.matching.controller;
+
+import com.matching.domain.DoneProject;
+import com.matching.domain.User;
+import com.matching.repository.DoneProjectRepository;
+import com.matching.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class DoneProjectControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DoneProjectRepository doneProjectRepository;
+
+    private DoneProject doneProject;
+
+    @Before
+    public void setMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+
+        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+
+        doneProject = DoneProject.builder().user(user).title("테스트 프로젝트").summary("테스트 프로젝트 입니다.")
+                .content("테스트 내용").createdDate(LocalDateTime.now()).startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now()).build();
+
+        doneProjectRepository.save(doneProject);
+    }
+
+    @Test
+    public void getDoneProjectTest() throws Exception {
+        mockMvc.perform(get("/api/doneproject/" + doneProject.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/doneproject/" + doneProject.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getDoneProjectUsedSkillsTest() throws Exception {
+        mockMvc.perform(get("/api/doneproject/" + doneProject.getIdx() + "/usedskills").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/doneproject/" + doneProject.getIdx() + "/usedskills"))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
@@ -1,0 +1,92 @@
+package com.matching.controller;
+
+import com.matching.domain.User;
+import com.matching.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ProfileControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @Before
+    public void setMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+
+        user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+    }
+
+    @Test
+    public void getProfileTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/profile/" + user.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProfileSkillsTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/skills").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/profile/" + user.getIdx() + "/skills"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProfileProjectsTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/projects").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/profile/" + user.getIdx() + "/projects"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProfileDoneProjectsTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/doneprojects").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/profile/" + user.getIdx() + "/doneprojects"))
+                .andExpect(status().isOk());
+    }
+
+
+}

--- a/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
@@ -1,0 +1,193 @@
+package com.matching.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.domain.*;
+import com.matching.domain.dto.ProjectDTO;
+import com.matching.domain.enums.LocationType;
+import com.matching.domain.enums.PositionType;
+import com.matching.domain.enums.ProjectStatus;
+import com.matching.domain.enums.UserProjectStatus;
+import com.matching.domain.key.UserProjectKey;
+import com.matching.repository.*;
+import com.matching.service.UserService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.parameters.P;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ProjectControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private UserProjectRepository userProjectRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserService userService;
+
+    private Project project;
+
+    private UserDetails userDetails;
+
+    @Before
+    public void setMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password(passwordEncoder.encode("test_password"))
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+
+        project = Project.builder().leader(user).title("테스트프로젝트").content("테스트 생성").summary("테스트 프로젝트")
+                .status(ProjectStatus.getRandomProjectStatus()).location(LocationType.getRandomLocationType())
+                .createdDate(LocalDateTime.now()).designerRecruits(1).developerRecruits(1).etcRecruits(1).marketerRecruits(1).plannerRecruits(1)
+                .socialUrl("https://github.com/testUser/testProject").build();
+
+        projectRepository.save(project);
+
+        UserProjectKey userProjectKey = new UserProjectKey(user.getIdx(), project.getIdx());
+
+        UserProject userProject = UserProject.builder().id(userProjectKey).user(user).project(project).simpleProfile("자기소개")
+                .position(PositionType.getRandomPositionType()).status(UserProjectStatus.getRandomUserProjectStatus())
+                .build();
+
+        userProjectRepository.save(userProject);
+
+        Comment comment = Comment.builder().project(project).writer(user).content("테스트 댓글").createdDate(LocalDateTime.now())
+                .build();
+
+        commentRepository.save(comment);
+
+    }
+
+    @Test
+    public void getProjectsJsonViewTest() throws Exception {
+        mockMvc.perform(get("/api/projects"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/projects"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProjectsJsonViewTes2t() throws Exception {
+        mockMvc.perform(get("/api/projects?location=BUSAN"))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/projects"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProjectJsonViewTest() throws Exception {
+        mockMvc.perform(get("/api/project/" + project.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/project/" + project.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProjectCommentsTest() throws Exception {
+        mockMvc.perform(get("/api/project/" + project.getIdx() + "/comments").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/project/" + project.getIdx() + "/comments"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProjectMembersTest() throws Exception {
+        mockMvc.perform(get("/api/project/" + project.getIdx() + "/members").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/project/" + project.getIdx() + "/members"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProjectTagsTest() throws Exception {
+        mockMvc.perform(get("/api/project/" + project.getIdx() + "/tags").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/project/" + project.getIdx() + "/tags"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void postProjectTest() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).alwaysDo(print()).build();
+
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        User user = User.builder().nick("Test User").email("Test_User1@gmail.com").password(passwordEncoder.encode("test_password"))
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+
+        userDetails = userService.loadUserByUsername("Test_User1@gmail.com");
+
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트").createdDate(LocalDateTime.now())
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+    }
+
+
+}

--- a/Project-Matching/src/test/java/com/matching/controller/RegisterControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/RegisterControllerTest.java
@@ -1,0 +1,78 @@
+package com.matching.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.domain.UserSkill;
+import com.matching.domain.dto.UserDTO;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class RegisterControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setup() throws Exception {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+    }
+
+    @Test
+    public void postUserTest() throws Exception {
+        Set<UserSkill> userSkills = new HashSet<>();
+
+        userSkills.add(UserSkill.builder().text("테스트 유저 스길 1").build());
+        userSkills.add(UserSkill.builder().text("유저 스길 2").build());
+
+        UserDTO userDTO = UserDTO.builder().email("simpleUser@gamil.com").password("1108sun@#!").confirmPassword("1108sun@#!")
+                .nickname("simpleUser").description("이러이러한 사람입니다.").socialUrl("https://github.com").investTime(3)
+                .userSkills(userSkills).build();
+
+        mockMvc.perform(post("/api/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userDTO)))
+                        .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void nickCheckTest() throws Exception {
+        mockMvc.perform(post("/api/register/nickcheck")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString("SimpleUser2222")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void emailCheckTest() throws Exception {
+        mockMvc.perform(post("/api/register/emailcheck")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString("SimpleUser2222@gmail.com")))
+                .andExpect(status().isOk());
+    }
+
+}

--- a/Project-Matching/src/test/java/com/matching/controller/TagControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/TagControllerTest.java
@@ -1,0 +1,140 @@
+package com.matching.controller;
+
+import com.matching.domain.*;
+import com.matching.repository.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TagControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private DoneProjectRepository doneProjectRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private UserSkillRepository userSkillRepository;
+
+    @Autowired
+    private UsedSkillRepository usedSkillRepository;
+
+    private Tag tag;
+
+    private UsedSkill usedSkill;
+
+    private UserSkill userSkill;
+
+    @Before
+    public void setMockMvc() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .alwaysDo(print())
+                .build();
+
+        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+
+        DoneProject doneProject = DoneProject.builder().user(user).title("테스트 프로젝트").summary("테스트 프로젝트 입니다.")
+                .content("테스트 내용").createdDate(LocalDateTime.now()).startDate(LocalDateTime.now())
+                .endDate(LocalDateTime.now()).build();
+
+        doneProjectRepository.save(doneProject);
+
+        tag = Tag.builder().text("테스트 태그1").build();
+        tagRepository.save(tag);
+
+        userSkill = UserSkill.builder().text("테스트 유저 스킬").user(user).build();
+        userSkillRepository.save(userSkill);
+
+        usedSkill = UsedSkill.builder().text("테스트 Done 프로젝트 스킬").doneProject(doneProject).build();
+        usedSkillRepository.save(usedSkill);
+    }
+
+    @Test
+    public void getTagsTest() throws Exception {
+        mockMvc.perform(get("/api/tags").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/tags"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getTagTest() throws Exception {
+        mockMvc.perform(get("/api/tag/" + tag.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/tag/" + tag.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getUserSkillsTest() throws Exception {
+        mockMvc.perform(get("/api/userskills").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/userskills"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getUserSkillTest() throws Exception {
+        mockMvc.perform(get("/api/userskill/" + userSkill.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/userskill/" + userSkill.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getUsedSkillsTest() throws Exception {
+        mockMvc.perform(get("/api/usedskills").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/usedskills"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getUsedSkillTest() throws Exception {
+        mockMvc.perform(get("/api/usedskill/" + usedSkill.getIdx()).with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/usedskill/" + usedSkill.getIdx()))
+                .andExpect(status().isOk());
+    }
+}

--- a/Project-Matching/src/test/java/com/matching/domain/JwtTokenTest.java
+++ b/Project-Matching/src/test/java/com/matching/domain/JwtTokenTest.java
@@ -39,8 +39,7 @@ public class JwtTokenTest {
 
     @Test
     public void jwtTokenCreateTest() {
-        JwtToken jwtToken = JwtToken.builder().token(UUID.randomUUID().toString()).status(true).user(user).build();
-        jwtToken.setExpiryDate(60);
+        JwtToken jwtToken = JwtToken.builder().token(UUID.randomUUID().toString()).build();
         testEntityManager.persist(jwtToken);
 
         assertThat(jwtTokenRepository.getOne(jwtToken.getIdx())).isNotNull().isEqualTo(jwtToken);
@@ -48,12 +47,10 @@ public class JwtTokenTest {
 
     @Test
     public void jwtTokenCreateAndSearchTest() {
-        JwtToken jwtToken1 = JwtToken.builder().token(UUID.randomUUID().toString()).status(true).user(user).build();
-        jwtToken1.setExpiryDate(60);
+        JwtToken jwtToken1 = JwtToken.builder().token(UUID.randomUUID().toString()).build();
         testEntityManager.persist(jwtToken1);
 
-        JwtToken jwtToken2 = JwtToken.builder().token(UUID.randomUUID().toString()).status(true).user(user).build();
-        jwtToken2.setExpiryDate(60);
+        JwtToken jwtToken2 = JwtToken.builder().token(UUID.randomUUID().toString()).build();
         testEntityManager.persist(jwtToken2);
 
         List<JwtToken> jwtTokenList = jwtTokenRepository.findAll();
@@ -66,12 +63,10 @@ public class JwtTokenTest {
 
     @Test
     public void jwtTokenCreateAndDeleteTest() {
-        JwtToken jwtToken1 = JwtToken.builder().token(UUID.randomUUID().toString()).status(true).user(user).build();
-        jwtToken1.setExpiryDate(60);
+        JwtToken jwtToken1 = JwtToken.builder().token(UUID.randomUUID().toString()).build();
         testEntityManager.persist(jwtToken1);
 
-        JwtToken jwtToken2 = JwtToken.builder().token(UUID.randomUUID().toString()).status(true).user(user).build();
-        jwtToken2.setExpiryDate(60);
+        JwtToken jwtToken2 = JwtToken.builder().token(UUID.randomUUID().toString()).build();
         testEntityManager.persist(jwtToken2);
 
         jwtTokenRepository.deleteAll();

--- a/Project-Matching/src/test/java/com/matching/domain/dto/UserDTOTest.java
+++ b/Project-Matching/src/test/java/com/matching/domain/dto/UserDTOTest.java
@@ -1,0 +1,15 @@
+package com.matching.domain.dto;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserDTOTest {
+
+    @Test
+    public void userDTOCreateTest() {
+        UserDTO userDTO = new UserDTO();
+
+        assertThat(userDTO).isNotNull();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,8 +18,24 @@ Project - Side Project Member Matching Platform
 
 * Entity 모델링 명세 [확인](https://docs.google.com/spreadsheets/d/1kbpWNSX8oapVMX6U6IQtt3sRyn1DrJNmXETlUz-EkQg/edit#gid=0)
 
-
 * Entity Relation Diagram [확인](https://drive.google.com/file/d/1tmBT3GAL3OIpRocH-hIGdo70-vzptTSo/view)
+
+### 개발 방법
+<details><summary>세부정보</summary>
+
+* 개발과 관련된 모든 이야기는 [Issues](https://github.com/perfect-matching/perfectmatching-backend/issues)에서 진행합니다.
+
+    * 급한 용무는 우선 순위에 따라서 카카오톡 또는 슬랙과 같은 메신저를 이용합니다.
+
+* API 및 모델링 명세를 주기적으로 최신화하면서 `README.md`를 잘 관리합니다. 
+
+* **Fork**를 통한 PR을 지향합니다.
+
+* 아래와 같은 Git Workflow를 지향하며 지키려고 노력합니다. ([참고](https://nvie.com/posts/a-successful-git-branching-model/?))
+
+    <img width=750, height=850, src="https://camo.githubusercontent.com/7f2539ff6001fe7700853313e7cdb7fd4602e16a/68747470733a2f2f6e7669652e636f6d2f696d672f6769742d6d6f64656c4032782e706e67">
+
+</details>
 
 ### 실행 방법
 <details><summary>세부정보</summary>
@@ -113,6 +129,9 @@ Project - Side Project Member Matching Platform
     | `/api/tag/{idx}` | [GET](https://donghun-dev.kro.kr:8083/api/tag/1/) | idx에 따른 Tag를 가져오기 위한 api |
     | `/api/userskill/{idx}` | [GET](https://donghun-dev.kro.kr:8083/api/userskill/1/) | idx에 따른 UserSkill을 가져오기 위한 api |
     | `/api/usedskill/{idx}` | [GET](https://donghun-dev.kro.kr:8083/api/usedskill/1/) | idx에 따른 UsedSkill을 가져오기 위한 api |
+    | `/api/tags` | [GET](https://donghun-dev.kro.kr:8083/api/tags) | DB에 등록되어 있는 Tag들을 가져오기 위한 api |
+    | `/api/userskills` | [GET](https://donghun-dev.kro.kr:8083/api/userskills) | DB에 등록되어 있는 UserSkill들을 가져오기 위한 api |
+    | `/api/usedskills` | [GET](https://donghun-dev.kro.kr:8083/api/usedskills) | DB에 등록되어 있는 UsedSkill들을 가져오기 위한 api |
 
 * POST
 
@@ -121,6 +140,10 @@ Project - Side Project Member Matching Platform
     | `/api/project` | POST | Project를 생성하기 위한 요청 api |
     | `/api/login` | POST | 서버에 로그인을 요청하기 위한 api |
     | `/api/logout` | POST | 서버에 로그아웃을 요청하기 위한 api |
+    | `/api/register` | POST | User 생성을 위해서 회원가입을 요청하는 api |
+    | `/api/register/nickcheck` | POST | User 생성을 위해 회원가입시 닉네임 중복 체크를 요청하는 api |
+    | `/api/register/emailcheck` | POST | User 생성을 위해 회원가입시 이메일 중복 체크를 요청하는 api |
+    | `/api/project` | POST | Project 생성을 요청하기 위한 api |
 
 * PUT
 


### PR DESCRIPTION
- `User` 생성 및 `Project` 개설을 위한 Post 로직 작성 (#63)

- 각 태그들(`Tag`, `UserSkill`, `UsedSkill`)을 전체 불러올 수 있는 API 생성 (#64)

- 프로젝트 리스트 페이지에서 아이템 가져오는 갯수를 4개에서 12개로 변경. (#65)

- 클라이언트에서 로그인 요청시 `CORS` 문제가 일어나는 버그를 해결하기 위해 Spring Security 로직 일부 변경. (#67)

- 현재 로그인 API에서 `JWT Token` 만료 방식 및 DB 저장 방식을 변경. -> 이전 로직 과는 다르게 생성시에 `JWT Token`을 DB에 저장하지 않고 로그아웃시에 저장을 하는 방식으로 DB에서 사용된 `JWT Token`을 블랙리스트로 관리하는 방식으로 변경. (#62)

- `JWT Token`의 `payload` 부분에 담기는 정보들의 양식을 변경. (#68)

- 추가된 API 들에 의해서 `README.md`에 API 명세 최신화. (#10)

- `README.md`에 개발방법 부분 추가.

- `Controller` 들에 대한 테스트 코드들 추가.

- `JWT Token` 도메인의 text 명세 수정. (300 -> 500)

  - 명세 수정의 이유는 `JWT Token`의 `payload` 부분에 담기는 정보 양식 변경으로 인해 토큰의 길이 증가로 인해서 변경하게 되었음. (#68)