### PR TITLE
Added Project와 Commnet 생성, 수정, 삭제 요청 로직 추가 및 클라이언트 쪽에서 발생한 버그Fix. 

### DIFF
--- a/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
+++ b/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.matching.config;
 import com.matching.config.filter.JwtAuthenticationFilter;
 import com.matching.config.filter.JwtAuthorizationFilter;
 import com.matching.config.handler.CustomLogoutSuccessHandler;
-import com.matching.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,6 +37,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         filter.setForceEncoding(true);
 
         http.cors().
+                and().
+                    csrf().
                 and().
                     httpBasic()
                 .and()

--- a/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthenticationFilter.java
+++ b/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import com.matching.config.auth.SecurityConstants;
 import com.matching.repository.UserRepository;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.var;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -92,7 +93,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 .claim("email", user.getUsername())
                 .claim("nickname", userRepository.findByEmail(user.getUsername()).getNick())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1800000))
+                .setExpiration(new Date(System.currentTimeMillis() + 3600000))
                 .claim("role", roles)
                 .compact();
 

--- a/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthorizationFilter.java
+++ b/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthorizationFilter.java
@@ -4,7 +4,6 @@ import com.matching.config.exception.InvalidTokenException;
 import com.matching.config.auth.SecurityConstants;
 import com.matching.repository.JwtTokenRepository;
 import io.jsonwebtoken.*;
-import lombok.var;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
@@ -68,7 +67,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             try {
                 byte[] signingKey = SecurityConstants.JWT_SECRET.getBytes();
 
-                var parsedToken = Jwts.parser()
+                Jws<Claims> parsedToken = Jwts.parser()
                         .setSigningKey(signingKey)
                         .parseClaimsJws(token.replace("Bearer ", ""));
 

--- a/Project-Matching/src/main/java/com/matching/controller/CommentController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.matching.controller;
 
+import com.matching.domain.dto.CommentDTO;
 import com.matching.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
@@ -7,12 +8,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
@@ -27,7 +28,7 @@ public class CommentController {
     @GetMapping(value = "/{idx}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> getComment(@PathVariable Long idx, HttpServletResponse response) {
         response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
-        response.setHeader("Location", "/api//comment/" + idx );
+        response.setHeader("Location", "/api/comment/" + idx );
 
         if(commentService.findComment(idx))
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -35,5 +36,42 @@ public class CommentController {
         Resource<?> resource = commentService.getComments(idx);
         resource.add(linkTo(methodOn(CommentController.class).getComment(idx, response)).withSelfRel());
         return ResponseEntity.ok(resource);
+    }
+
+
+    @PostMapping
+    public ResponseEntity<?> postComment(@Valid @RequestBody CommentDTO commentDTO, BindingResult result, HttpServletRequest request,
+                                         HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/comment" );
+
+        if(result.hasErrors()) {
+            StringBuilder msg = commentService.validation(result);
+            return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        return commentService.postComment(commentDTO, request);
+    }
+
+    @PutMapping(value = "/{idx}")
+    public ResponseEntity<?> putComment(@Valid @RequestBody CommentDTO commentDTO, BindingResult result, @PathVariable Long idx,
+                                        HttpServletRequest request,HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/comment/" + idx );
+
+        if(result.hasErrors()) {
+            StringBuilder msg = commentService.validation(result);
+            return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        return commentService.putComment(commentDTO, request, idx);
+    }
+
+    @DeleteMapping(value = "/{idx}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long idx, HttpServletResponse response, HttpServletRequest request) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/comment/" + idx );
+
+        return commentService.deleteComment(idx, request);
     }
 }

--- a/Project-Matching/src/main/java/com/matching/controller/ProjectController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/ProjectController.java
@@ -3,7 +3,6 @@ package com.matching.controller;
 import com.matching.domain.Project;
 import com.matching.domain.dto.ProjectDTO;
 import com.matching.domain.enums.LocationType;
-import com.matching.service.ProfileService;
 import com.matching.service.ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -17,11 +16,10 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.util.List;
@@ -127,7 +125,7 @@ public class ProjectController {
     }
 
     @PostMapping(value = "/project")
-    public ResponseEntity<?> postProject(@Valid @RequestBody ProjectDTO projectDTO, BindingResult result, @AuthenticationPrincipal User user, HttpServletResponse response) {
+    public ResponseEntity<?> postProject(@Valid @RequestBody ProjectDTO projectDTO, BindingResult result, HttpServletRequest request, HttpServletResponse response) {
         response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
         response.setHeader("Location", "/api/project");
 
@@ -136,7 +134,29 @@ public class ProjectController {
             return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
         }
 
-        return projectService.postProject(projectDTO, user);
+        return projectService.postProject(projectDTO, request);
+    }
+
+    @PutMapping(value = "/project/{idx}")
+    public ResponseEntity<?> putProject(@Valid @RequestBody ProjectDTO projectDTO, BindingResult result, @PathVariable Long idx,
+                                        HttpServletRequest request, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/project/" + idx);
+
+        if(result.hasErrors()) {
+            StringBuilder msg = projectService.validation(result);
+            return new ResponseEntity<>(msg, HttpStatus.BAD_REQUEST);
+        }
+
+        return projectService.putProject(projectDTO, request, idx);
+    }
+
+    @DeleteMapping(value = "/project/{idx}")
+    public ResponseEntity<?> deleteProject(@PathVariable Long idx, HttpServletResponse response, HttpServletRequest request) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/project/" + idx);
+
+        return projectService.deleteProject(idx, request);
     }
 
 }

--- a/Project-Matching/src/main/java/com/matching/domain/Project.java
+++ b/Project-Matching/src/main/java/com/matching/domain/Project.java
@@ -14,6 +14,9 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+import static javax.persistence.CascadeType.DETACH;
+import static javax.persistence.CascadeType.PERSIST;
+
 @Entity
 @Data
 @Table
@@ -70,15 +73,15 @@ public class Project implements Serializable {
     @Column(length = 100)
     private String socialUrl;
 
-    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JsonBackReference
     private Set<Comment> comments = new HashSet<>();
 
-    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JsonBackReference
     private Set<UserProject> userProjects = new HashSet<>();
 
-    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JsonBackReference
     private Set<ProjectTag> projectTags = new HashSet<>();
 

--- a/Project-Matching/src/main/java/com/matching/domain/Tag.java
+++ b/Project-Matching/src/main/java/com/matching/domain/Tag.java
@@ -13,6 +13,9 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
+import static javax.persistence.CascadeType.DETACH;
+import static javax.persistence.CascadeType.PERSIST;
+
 @Entity
 @Data
 @Table

--- a/Project-Matching/src/main/java/com/matching/domain/User.java
+++ b/Project-Matching/src/main/java/com/matching/domain/User.java
@@ -25,7 +25,7 @@ public class User implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "writer", fetch = FetchType.LAZY)
     @JsonBackReference
     private Set<Comment> comments = new HashSet<>();
 

--- a/Project-Matching/src/main/java/com/matching/domain/dto/CommentDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/CommentDTO.java
@@ -9,6 +9,7 @@ import org.hibernate.validator.constraints.Length;
 import org.springframework.hateoas.core.Relation;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Data
@@ -20,23 +21,21 @@ public class CommentDTO {
 
     private Long commentIdx;
 
-    @NotBlank
     @Length(max = 30, min = 1)
     private String userName;
 
     private Long userIdx;
 
-    @NotBlank
     @Length(max = 255, min = 1)
     private String projectTitle;
 
+    @NotNull(message = "project Idx가 비어있습니다.")
     private Long projectIdx;
 
-    @NotBlank
+    @NotBlank(message = "내용이 비어있습니다.")
     @Length(max = 255, min = 1)
     private String content;
 
-    @NotBlank
     private LocalDateTime createdDate;
 
     private LocalDateTime modifiedDate;

--- a/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
@@ -52,7 +52,7 @@ public class DoneProjectDTO {
 
     private String socialUrl;
 
-    private final Set<UsedSkill> usedSkills = new HashSet<>();
+    private Set<UsedSkill> usedSkills = new HashSet<>();
 
     public DoneProjectDTO(DoneProject doneProject) {
         this.doneProjectIdx = doneProject.getIdx();

--- a/Project-Matching/src/main/java/com/matching/domain/dto/ProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/ProjectDTO.java
@@ -1,10 +1,8 @@
 package com.matching.domain.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.matching.domain.Project;
+import com.matching.domain.ProjectTag;
 import com.matching.domain.Tag;
-import com.matching.domain.enums.LocationType;
 import com.matching.domain.enums.PositionType;
 import com.matching.domain.enums.UserProjectStatus;
 import com.matching.repository.UserProjectRepository;
@@ -14,8 +12,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -49,7 +45,6 @@ public class ProjectDTO {
     @Length(max = 255, min = 1)
     private String location;
 
-    @NotNull
     private LocalDateTime createdDate;
 
     private LocalDateTime modifiedDate;
@@ -88,6 +83,10 @@ public class ProjectDTO {
 
     private Set<Tag> tags = new HashSet<>();
 
+    private Set<Tag> addTags = new HashSet<>();
+
+    private Set<Tag> removeTags = new HashSet<>();
+
     public ProjectDTO(Project project, UserProjectRepository userProjectRepo) {
         this.projectIdx = project.getIdx();
         this.title = project.getTitle();
@@ -110,5 +109,8 @@ public class ProjectDTO {
         this.currentPlanner = userProjectRepo.countByProjectAndPositionAndStatus(project, PositionType.PLANNER, UserProjectStatus.MATCHING);
         this.currentEtc = userProjectRepo.countByProjectAndPositionAndStatus(project, PositionType.ETC, UserProjectStatus.MATCHING);
         this.socialUrl = project.getSocialUrl();
+
+        for(ProjectTag projectTag : project.getProjectTags())
+            tags.add(projectTag.getTag());
     }
 }

--- a/Project-Matching/src/main/java/com/matching/domain/dto/UserDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/UserDTO.java
@@ -45,7 +45,7 @@ public class UserDTO {
 
     @NotBlank(message = "자기소개가 비어있습니다.")
     @Length(max = 500, message = "자기소개는 500자 내외로 작성해주시길 바랍니다.")
-    private String description;
+    private String summary;
 
     @NotNull(message = "투자 시간이 비어있습니다.")
     private Integer investTime;

--- a/Project-Matching/src/main/java/com/matching/repository/CommentRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/CommentRepository.java
@@ -11,4 +11,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByProject(Project project);
 
     Comment findByIdx(Long idx);
+
+    Comment findByContent(String content);
 }

--- a/Project-Matching/src/main/java/com/matching/repository/ProjectRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/ProjectRepository.java
@@ -11,6 +11,8 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     Project findByIdx(long idx);
 
+    Project findByTitle(String title);
+
     Page<Project> findAllByOrderByIdxDesc(Pageable pageable);
 
     Page<Project> findByLocationOrderByIdxDesc(LocationType location, Pageable pageable);

--- a/Project-Matching/src/main/java/com/matching/repository/ProjectTagRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/ProjectTagRepository.java
@@ -5,8 +5,12 @@ import com.matching.domain.ProjectTag;
 import com.matching.domain.key.ProjectTagKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 public interface ProjectTagRepository extends JpaRepository<ProjectTag, ProjectTagKey> {
     List<ProjectTag> findByProject(Project project);
+
+    @Transactional
+    void deleteByProject(Project project);
 }

--- a/Project-Matching/src/main/java/com/matching/service/CommentService.java
+++ b/Project-Matching/src/main/java/com/matching/service/CommentService.java
@@ -1,11 +1,27 @@
 package com.matching.service;
 
+import com.matching.config.auth.SecurityConstants;
 import com.matching.domain.Comment;
+import com.matching.domain.Project;
+import com.matching.domain.User;
 import com.matching.domain.dto.CommentDTO;
 import com.matching.repository.CommentRepository;
+import com.matching.repository.ProjectRepository;
+import com.matching.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 public class CommentService {
@@ -13,6 +29,11 @@ public class CommentService {
     @Autowired
     private CommentRepository commentRepository;
 
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     public boolean findComment(Long idx) {
         return commentRepository.findByIdx(idx) == null;
@@ -22,5 +43,72 @@ public class CommentService {
         Comment comment = commentRepository.findByIdx(idx);
         CommentDTO commentDTO = new CommentDTO(comment);
         return new Resource<>(commentDTO);
+    }
+
+    public StringBuilder validation(BindingResult result) {
+        List<ObjectError> list = result.getAllErrors();
+        StringBuilder msg = new StringBuilder();
+        for (ObjectError error : list)
+            msg.append(error.getDefaultMessage()).append("\n");
+        return msg;
+    }
+
+    public ResponseEntity<?> postComment(CommentDTO commentDTO, HttpServletRequest request) {
+
+        String token = request.getHeader(SecurityConstants.TOKEN_HEADER);
+
+        Jws<Claims> parsedToken = Jwts.parser()
+                .setSigningKey(SecurityConstants.JWT_SECRET.getBytes())
+                .parseClaimsJws(token.replace("Bearer ", ""));
+
+        User user = userRepository.findByEmail((String) parsedToken.getBody().get("email"));
+        Project project = projectRepository.findByIdx(commentDTO.getProjectIdx());
+
+        Comment comment = Comment.builder().content(commentDTO.getContent()).createdDate(LocalDateTime.now()).build();
+
+        user.addComment(comment);
+        project.addComment(comment);
+        commentRepository.save(comment);
+
+        return new ResponseEntity<>("{}", HttpStatus.CREATED);
+    }
+
+    public ResponseEntity<?> putComment(CommentDTO commentDTO, HttpServletRequest request, Long idx) {
+
+        Comment comment = commentRepository.findByIdx(idx);
+
+        String token = request.getHeader(SecurityConstants.TOKEN_HEADER);
+
+        Jws<Claims> parsedToken = Jwts.parser()
+                .setSigningKey(SecurityConstants.JWT_SECRET.getBytes())
+                .parseClaimsJws(token.replace("Bearer ", ""));
+
+        if(!userRepository.findByEmail((String) parsedToken.getBody().get("email")).getIdx().equals(comment.getWriter().getIdx()))
+            return new ResponseEntity<>("댓글 작성자가 아닙니다.", HttpStatus.BAD_REQUEST);
+
+        comment.setContent(commentDTO.getContent());
+        comment.setModifiedDate(LocalDateTime.now());
+
+        commentRepository.save(comment);
+
+        return new ResponseEntity<>("{}", HttpStatus.OK);
+    }
+
+
+    public ResponseEntity<?> deleteComment(Long idx, HttpServletRequest request) {
+        Comment comment = commentRepository.findByIdx(idx);
+
+        String token = request.getHeader(SecurityConstants.TOKEN_HEADER);
+
+        Jws<Claims> parsedToken = Jwts.parser()
+                .setSigningKey(SecurityConstants.JWT_SECRET.getBytes())
+                .parseClaimsJws(token.replace("Bearer ", ""));
+
+        if(!userRepository.findByEmail((String) parsedToken.getBody().get("email")).getIdx().equals(comment.getWriter().getIdx()))
+            return new ResponseEntity<>("댓글 작성자가 아닙니다.", HttpStatus.BAD_REQUEST);
+
+        commentRepository.deleteById(comment.getIdx());
+
+        return new ResponseEntity<>("{}", HttpStatus.OK);
     }
 }

--- a/Project-Matching/src/main/java/com/matching/service/RegisterService.java
+++ b/Project-Matching/src/main/java/com/matching/service/RegisterService.java
@@ -44,7 +44,7 @@ public class RegisterService {
     public ResponseEntity<?> postUser(UserDTO userDTO) {
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
         User user = User.builder().createdDate(LocalDateTime.now()).email(userDTO.getEmail()).nick(userDTO.getNickname()).
-                password(passwordEncoder.encode(userDTO.getPassword())).profileImg(userDTO.getProfileImag()).description(userDTO.getDescription()).
+                password(passwordEncoder.encode(userDTO.getPassword())).profileImg(userDTO.getProfileImag()).description(userDTO.getSummary()).
                 investTime(userDTO.getInvestTime()).socialUrl(userDTO.getSocialUrl()).build();
         userRepository.save(user);
 

--- a/Project-Matching/src/test/java/com/matching/controller/CommentControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/CommentControllerTest.java
@@ -1,28 +1,40 @@
 package com.matching.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.config.auth.SecurityConstants;
 import com.matching.domain.Comment;
 import com.matching.domain.Project;
 import com.matching.domain.User;
+import com.matching.domain.dto.CommentDTO;
 import com.matching.domain.enums.LocationType;
 import com.matching.domain.enums.ProjectStatus;
 import com.matching.repository.CommentRepository;
 import com.matching.repository.ProjectRepository;
 import com.matching.repository.UserRepository;
+import com.matching.service.UserService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -36,6 +48,9 @@ public class CommentControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
     private UserRepository userRepository;
 
     @Autowired
@@ -44,7 +59,12 @@ public class CommentControllerTest {
     @Autowired
     private CommentRepository commentRepository;
 
+    @Autowired
+    private UserService userService;
+
     private Comment comment;
+
+    private String token;
 
     @Before
     public void setMockMvc() {
@@ -52,13 +72,15 @@ public class CommentControllerTest {
                 .alwaysDo(print())
                 .build();
 
-        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        User user = User.builder().nick("Test User").email("Test_User@gmail.com").password(passwordEncoder.encode("test_password"))
                 .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
                 .investTime(4).socialUrl("https://github.com/testUser").build();
 
         userRepository.save(user) ;
 
-        Project project = Project.builder().leader(user).title("테스트 프로젝트").content("테스트 생성").summary("테스트 프로젝트")
+        Project project = Project.builder().leader(user).title("테스트 프로젝트1234").content("테스트 생성").summary("테스트 프로젝트")
                 .status(ProjectStatus.getRandomProjectStatus()).location(LocationType.getRandomLocationType())
                 .createdDate(LocalDateTime.now()).designerRecruits(1).developerRecruits(1).etcRecruits(1).marketerRecruits(1).plannerRecruits(1)
                 .socialUrl("https://github.com/testUser/testProject").build();
@@ -70,15 +92,87 @@ public class CommentControllerTest {
                 .build();
 
         commentRepository.save(comment);
+
+        UserDetails userDetails = userService.loadUserByUsername(user.getEmail());
+
+        List<String> roles = userDetails.getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        token = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, SecurityConstants.JWT_SECRET.getBytes())
+                .setHeaderParam("typ", SecurityConstants.TOKEN_TYPE)
+                .setIssuer(SecurityConstants.TOKEN_ISSUER)
+                .setAudience(SecurityConstants.TOKEN_AUDIENCE)
+                .setSubject("Perfect-Matching JWT Token")
+                .claim("idx", userRepository.findByEmail(user.getEmail()).getIdx())
+                .claim("email", user.getEmail())
+                .claim("nickname", user.getNick())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1800000))
+                .claim("role", roles)
+                .compact();
     }
 
     @Test
     public void getCommentTest() throws Exception {
-        mockMvc.perform(get("/api/project/" + comment.getIdx()).with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/comment/" + comment.getIdx()).with(user("Test_User@gmail.com")
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
-                .andExpect(redirectedUrl("/api/project/" + comment.getIdx()))
+                .andExpect(redirectedUrl("/api/comment/" + comment.getIdx()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void postCommentTest() throws Exception {
+
+        Long projectIdx = projectRepository.findByTitle("테스트 프로젝트1234").getIdx();
+
+        CommentDTO commentDTO = CommentDTO.builder().content("테스트 코드에서 작성하는 댓글").projectIdx(projectIdx).build();
+
+        mockMvc.perform(post("/api/comment").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(commentDTO)).with(user("Test_User@gmail.com").password("test_password")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void putCommentTest() throws Exception {
+        Long projectIdx = projectRepository.findByTitle("테스트 프로젝트1234").getIdx();
+
+        CommentDTO commentDTO = CommentDTO.builder().content("테스트 코드에서 작성하는 댓글").projectIdx(projectIdx).build();
+
+        mockMvc.perform(post("/api/comment").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(commentDTO)).with(user("Test_User@gmail.com").password("test_password")))
+                .andExpect(status().isCreated());
+
+        commentDTO.setContent("테스크 코드에서 수정된 댓글...");
+
+        mockMvc.perform(put("/api/comment/" + commentRepository.findByContent("테스트 코드에서 작성하는 댓글").getIdx())
+                .header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(commentDTO)).with(user("Test_User@gmail.com").password("test_password")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteCommentTest() throws Exception {
+        Long projectIdx = projectRepository.findByTitle("테스트 프로젝트1234").getIdx();
+
+        CommentDTO commentDTO = CommentDTO.builder().content("테스트 코드에서 작성하는 댓글").projectIdx(projectIdx).build();
+
+        mockMvc.perform(post("/api/comment").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(commentDTO)).with(user("Test_User@gmail.com").password("test_password")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/comment/" + commentRepository.findByContent("테스트 코드에서 작성하는 댓글").getIdx())
+                .header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(commentDTO)).with(user("Test_User@gmail.com").password("test_password")))
                 .andExpect(status().isOk());
     }
 

--- a/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
@@ -1,6 +1,7 @@
 package com.matching.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.config.auth.SecurityConstants;
 import com.matching.domain.*;
 import com.matching.domain.dto.ProjectDTO;
 import com.matching.domain.enums.LocationType;
@@ -10,15 +11,15 @@ import com.matching.domain.enums.UserProjectStatus;
 import com.matching.domain.key.UserProjectKey;
 import com.matching.repository.*;
 import com.matching.service.UserService;
-import org.junit.After;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.core.parameters.P;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -27,11 +28,13 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -67,6 +70,8 @@ public class ProjectControllerTest {
 
     private UserDetails userDetails;
 
+    private String token;
+
     @Before
     public void setMockMvc() {
         mockMvc = MockMvcBuilders.webAppContextSetup(context)
@@ -101,6 +106,26 @@ public class ProjectControllerTest {
 
         commentRepository.save(comment);
 
+        userDetails = userService.loadUserByUsername(user.getEmail());
+
+        List<String> roles = userDetails.getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        token = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, SecurityConstants.JWT_SECRET.getBytes())
+                .setHeaderParam("typ", SecurityConstants.TOKEN_TYPE)
+                .setIssuer(SecurityConstants.TOKEN_ISSUER)
+                .setAudience(SecurityConstants.TOKEN_AUDIENCE)
+                .setSubject("Perfect-Matching JWT Token")
+                .claim("idx", userRepository.findByEmail(user.getEmail()).getIdx())
+                .claim("email", user.getEmail())
+                .claim("nickname", user.getNick())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1800000))
+                .claim("role", roles)
+                .compact();
     }
 
     @Test
@@ -163,30 +188,74 @@ public class ProjectControllerTest {
 
     @Test
     public void postProjectTest() throws Exception {
-        mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).alwaysDo(print()).build();
-
-        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-
-        User user = User.builder().nick("Test User").email("Test_User1@gmail.com").password(passwordEncoder.encode("test_password"))
-                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
-                .investTime(4).socialUrl("https://github.com/testUser").build();
-
-        userRepository.save(user);
-
-        userDetails = userService.loadUserByUsername("Test_User1@gmail.com");
 
         Set<Tag> tag = new HashSet<>();
 
         tag.add(Tag.builder().text("테스트 코드 태그 1").build());
         tag.add(Tag.builder().text("테스트 코드 태그 2").build());
 
-        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트").createdDate(LocalDateTime.now())
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
                 .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
 
-        mockMvc.perform(post("/api/project")
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void putProjectTest() throws Exception {
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Set<Tag> tag2 = new HashSet<>();
+
+        tag2.add(Tag.builder().text("테스트 코드 태그 1(수정)").build());
+        tag2.add(Tag.builder().text("테스트 코드 태그 2(수정)").build());
+
+        projectdto.setTitle("수정된 프로젝트");
+        projectdto.setTags(tag2);
+
+        mockMvc.perform(put("/api/project/" + projectRepository.findByTitle("테스트 타이틀 12312321").getIdx()).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteProjectTest() throws Exception {
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Comment comment = Comment.builder().writer(userRepository.findByEmail("Test_User@gmail.com")).project(projectRepository.findByTitle("테스트 타이틀 12312321"))
+                .content("테스트 댓글").createdDate(LocalDateTime.now()).build();
+
+        commentRepository.save(comment);
+
+        mockMvc.perform(delete("/api/project/" + projectRepository.findByTitle("테스트 타이틀 12312321").getIdx()).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isOk());
     }
 
 

--- a/Project-Matching/src/test/java/com/matching/controller/RegisterControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/RegisterControllerTest.java
@@ -50,7 +50,7 @@ public class RegisterControllerTest {
         userSkills.add(UserSkill.builder().text("유저 스길 2").build());
 
         UserDTO userDTO = UserDTO.builder().email("simpleUser@gamil.com").password("1108sun@#!").confirmPassword("1108sun@#!")
-                .nickname("simpleUser").description("이러이러한 사람입니다.").socialUrl("https://github.com").investTime(3)
+                .nickname("simpleUser").summary("이러이러한 사람입니다.").socialUrl("https://github.com").investTime(3)
                 .userSkills(userSkills).build();
 
         mockMvc.perform(post("/api/register")

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ Project - Side Project Member Matching Platform
     $ git clone https://github.com/perfect-matching/perfectmatching-backend.git
     ```
 
-* 프로젝트 내 Project-Matching\src\main\java\com\matching\config 경로에 HttpConfig.java 삭제 또는 내용 주석처리.
+* 프로젝트 내 Project-Matching\src\main\java\com\matching\config 경로에 `HttpConfig.java` 삭제 또는 내용 주석처리.
+
+* DB는 MySQL을 쓴다고 가정.
+
+    * 다른 DB를 사용한다면, 그 DB에 맞게 설정을 해야함.
 
 * 프로젝트 내 Project-Matching\src\main\resources 경로에 `application.yml` 생성.
 
@@ -64,7 +68,7 @@ Project - Side Project Member Matching Platform
     ```yml
     spring:
         datasource:
-            url: jdbc:mysql://localhost/본인_DB
+            url: jdbc:mysql://localhost:3306/본인_DB?serverTimezone=UTC
             username: 본인_DB_User
             password: 본인_DB_User_Password
             driver-class-name: com.mysql.jdbc.Driver
@@ -143,17 +147,20 @@ Project - Side Project Member Matching Platform
     | `/api/register` | POST | User 생성을 위해서 회원가입을 요청하는 api |
     | `/api/register/nickcheck` | POST | User 생성을 위해 회원가입시 닉네임 중복 체크를 요청하는 api |
     | `/api/register/emailcheck` | POST | User 생성을 위해 회원가입시 이메일 중복 체크를 요청하는 api |
+    | `/api/comment` | POST | Comment를 생성하기 위해 요청하는 api |
 
 * PUT
 
     |URI(자원)| HTTP(행위) | 기능(표현) |
     |:---:|:---:|:---:|
     | `/api/project/{idx}` | PUT | Project의 idx에 따라 Project를 수정하기 위한 api |
+    | `/api/comment/{idx}` | PUT | Comment의 idx에 따라 Comment를 수정하기 위한 api |
 
 * DELETE
 
     |URI(자원)| HTTP(행위) | 기능(표현) |
     |:---:|:---:|:---:|
     | `/api/project/{idx}` | DELETE | Project의 idx에 따라 Projet를 삭제하기 위한 api |
+    | `/api/comment/{idx}` | DELETE | Comment의 idx에 따라 Comment를 삭제하기 위한 api |
 
 </details>

--- a/documents/get.md
+++ b/documents/get.md
@@ -1,3 +1,5 @@
+## GET - JSON Data Form Example
+
 * `https://donghun-dev.kro.kr:8083/api/projects`
 
   * 프로젝트 12개의 정보 출력.
@@ -90,6 +92,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/projects?offset=1`
 
   * 데이터 출력은 `/api/projects` 요청시와 동일하고 다음 항목들을 가져옴.
@@ -107,6 +110,7 @@
 
   * Fail : Code 403
 
+
 * `https://donghun-dev.kro.kr:8083/api/projects?location=SEOUL&offset=1`
 
   * 데이터 출력은 `/api/projects` 요청시와 동일하고 지역 정보가 서울인 항목의 다음 정보들을 가져옴.
@@ -114,6 +118,7 @@
   * Success : Code 200
 
   * Fail : Code 403
+
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER`
 
@@ -123,6 +128,7 @@
 
   * Fail : Code 403
 
+
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&offset=1`
 
   * 데이터 출력은 `/api/projects` 요청시와 동일하고 포지션 정보가 developer를 포함하고 있는 다음 항목 정보들을 가져옴.
@@ -130,6 +136,7 @@
   * Success : Code 200
 
   * Fail : Code 403
+
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&location=SEOUL`
 
@@ -139,6 +146,7 @@
 
   * Fail : Code 403
 
+
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&location=SEOUL&offset=1`
 
   * 데이터 출력은 `/api/projects` 요청시와 동일하고 포지션 정보가 developer를 포함하고 지역 정보가 서울인 항목의 다음 정보들을 가져옴.
@@ -146,6 +154,7 @@
   * Success : Code 200
 
   * Fail : Code 403
+
 
 * `https://donghun-dev.kro.kr:8083/api/project/1`
 
@@ -215,6 +224,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/project/1/comments`
 
@@ -301,6 +311,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/project/1/tags`
 
@@ -436,6 +447,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/profile/1/projects`
 
   * 유저의 {idx}의 진행중인 프로젝트의 정보들을 가져옴.
@@ -477,6 +489,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/profile/1/doneprojects`
 
@@ -543,6 +556,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/comment/1`
 
   * 댓글 {idx}의 정보를 가져옴.
@@ -569,6 +583,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/doneproject/1`
 
   * 진행했던 프로젝트 {idx}의 정보를 가져옴.
@@ -594,6 +609,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/doneproject/1/usedskills`
 
@@ -635,6 +651,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/tag/1`
 
   * {idx}의 태그 정보를 가져옴.
@@ -654,6 +671,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/userskill/1`
 
@@ -675,6 +693,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/usedskill/1`
 
   * {idx}의 태그 정보를 가져옴.
@@ -694,6 +713,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/tags`
 
@@ -735,6 +755,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/userskills`
 
   * {idx}의 태그 정보를 가져옴.
@@ -774,6 +795,7 @@
     }
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/usedskills`
 

--- a/documents/post.md
+++ b/documents/post.md
@@ -1,3 +1,5 @@
+## POST - JSON Data Form Example
+
 * `https://donghun-dev.kro.kr:8083/api/project`
 
   * POST Project JSON Form Data Example
@@ -11,7 +13,8 @@
       "title": "프로젝트 인원을 모집합니다.",
       "location": "서울",
       "summary": "~ 이러한 프로젝트의 인원을 찾고 있어요.",
-     "developerRecruits": 2,
+      "content": "이러한 내용을 구성하고 있습니다.",
+      "developerRecruits": 2,
       "designerRecruits": 1,
       "plannerRecruits": 4,
       "marketerRecruits": 4,
@@ -31,6 +34,7 @@
   }
   ```
 
+
 * `https://donghun-dev.kro.kr:8083/api/login`
 
   * SignIn JSON Form Data Example
@@ -47,7 +51,6 @@
   ```
 
 
-
 * `https://donghun-dev.kro.kr:8083/api/register`
 
   * SignUp JSON Form Data Example
@@ -62,7 +65,7 @@
      "password" : "113444@#$%abcde",
      "confirmPassword" : "113444@#$%abcde",
      "nickname" : "admin",
-     "description" : "저는 자바를 공부하고 있는 학생입니다.",
+     "summary" : "저는 자바를 공부하고 있는 학생입니다.",
      "investTime" : 3,
      "userSkills" : [
         {
@@ -77,6 +80,7 @@
      ]
   }
   ```
+
 
 * `https://donghun-dev.kro.kr:8083/api/register/nickcheck`
 
@@ -104,5 +108,21 @@
   ```JSON
   {
     "email" : "admin@email.com"
+  }
+  ```
+
+
+* `https://donghun-dev.kro.kr:8083/api/comment`
+
+  * POST Comment JSON Form Data Example
+
+  * Success : Code 200
+
+  * Fail : Code 403
+
+  ```JSON
+  {
+    "content" : "작성하고자 하는 댓글",
+    "projectIdx" : 1
   }
   ```


### PR DESCRIPTION
- 스프링 시큐리티 설정에 `csrf`를 막기 위한 보안 설정 추가.

- `JWT` 토큰 만료시간을 로그인 직후 30분에서 1시간으로 변경.

- 타입추론을 자동으로 해주던 `lombok`의 `var`를 제거하고, 원래 타입으로 변경.

- `Comment`의 `POST`, `PUT`, `DELETE` 요청 처리 로직 추가. (#77)

- `Project`의 `POST` 요청 로직 수정 및 `PUT`, `DELETE` 요청 로직 추가. (#76)

- `Project` 삭제 시 관계성이 걸려있던 `Comment`와 조인 테이블인 `ProjectTag`와 `UserProject`도 함께 삭제하기 위해, `CascadeType.REMOVE` 제약 추가.

- 클라이언트 쪽 `POST` 요청시에 `400` 에러가 일어나는 버그 픽스. -> 현재 유저 정보를 가져올 때 세션에서 가져올 경우, NP 문제가 일어나서 클라이언트에서 요청할 때 보내는 `JWT` 토큰을 이용해서 현재 유저 정보를 가져오는 것으로 로직을 변경. (#74)

- `projectDetail` 부분에 `tags` 프로퍼티가 빈 상태로 날라오는 버그 Fix -> `tags` 프로퍼티에 제대로 태그가 담겨서 날아가도록 변경. (#71)

- `README.md`에 새로 추가된 `api` 요청들의 명세 추가. (#10)

- `POST.md`에 `Comment` `POST` 요청시에 사용되는 `JSON` 데이터 폼 양식 추가. (#10)

- `/api/register` api의 `POST` 요청시에 보내는 `JSON` 프로퍼티 중 `description` 프로퍼티 이름을 `GET` 요청과 통일 시키기 위해서 `summary`로 변경. (#75)

- `Project`, `Comment`의 `POST`, `PUT`, `DELETE` 요청 로직 추가에 의한 컨트롤러 테스트 코드 추가.

- `README.md`의 실행방법 부분에 `yml` 양식 일부 변경.