### PR TITLE
add JwtResolver

### DIFF
--- a/Project-Matching/src/main/java/com/matching/config/auth/JwtResolver.java
+++ b/Project-Matching/src/main/java/com/matching/config/auth/JwtResolver.java
@@ -1,0 +1,24 @@
+package com.matching.config.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class JwtResolver {
+    private HttpServletRequest request;
+
+    public JwtResolver(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    public String getUserByToken() {
+        String token = request.getHeader(SecurityConstants.TOKEN_HEADER);
+        Jws<Claims> parsedToken = Jwts.parser()
+                .setSigningKey(SecurityConstants.JWT_SECRET.getBytes())
+                .parseClaimsJws(token.replace("Bearer ", ""));
+
+        return (String) parsedToken.getBody().get("email");
+    }
+}


### PR DESCRIPTION
* 기존의 api에서 jwt 토큰을 파싱하는 로직의 중복이 많아 별도의 클래스를
생성
* 해당 클래스는 HttpServletRequest Header JWT 토큰 값을 파싱하여 payload의 유저 정보를
가져옴
* issue: #83