### PR TITLE
Added Project 상세 로직 api, 프로젝트와 유저 매칭 로직 추가.

### DIFF
--- a/Project-Matching/src/main/java/com/matching/config/HttpConfig.java
+++ b/Project-Matching/src/main/java/com/matching/config/HttpConfig.java
@@ -1,46 +1,46 @@
-//package com.matching.config;
-//
-//import org.apache.catalina.Context;
-//import org.apache.catalina.connector.Connector;
-//import org.apache.tomcat.util.descriptor.web.SecurityCollection;
-//import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
-//import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
-//import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
-//import org.springframework.context.annotation.Bean;
-//import org.springframework.context.annotation.Configuration;
-//
-//@Configuration
-//public class HttpConfig {
-//
-//    private static final int HTTP_PORT = 8004;
-//    private static final int HTTPS_PORT = 8084;
-//    private static final String HTTP = "http";
-//    private static final String USER_CONSTRAINT = "CONFIDENTIAL";
-//
-//    @Bean
-//    public ServletWebServerFactory servletContainer() {
-//        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
-//            @Override
-//            protected void postProcessContext(Context context) {
-//                SecurityConstraint securityConstraint = new SecurityConstraint();
-//                securityConstraint.setUserConstraint(USER_CONSTRAINT);
-//                SecurityCollection collection = new SecurityCollection();
-//                collection.addPattern("/*");
-//                securityConstraint.addCollection(collection);
-//                context.addConstraint(securityConstraint);
-//            }
-//        };
-//        tomcat.addAdditionalTomcatConnectors(redirectConnector());
-//        return tomcat;
-//    }
-//
-//    private Connector redirectConnector() {
-//        Connector connector = new Connector(
-//                TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
-//        connector.setScheme(HTTP);
-//        connector.setPort(HTTP_PORT);
-//        connector.setSecure(false);
-//        connector.setRedirectPort(HTTPS_PORT);
-//        return connector;
-//    }
-//}
+package com.matching.config;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.connector.Connector;
+import org.apache.tomcat.util.descriptor.web.SecurityCollection;
+import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HttpConfig {
+
+    private static final int HTTP_PORT = 8004;
+    private static final int HTTPS_PORT = 8084;
+    private static final String HTTP = "http";
+    private static final String USER_CONSTRAINT = "CONFIDENTIAL";
+
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
+            @Override
+            protected void postProcessContext(Context context) {
+                SecurityConstraint securityConstraint = new SecurityConstraint();
+                securityConstraint.setUserConstraint(USER_CONSTRAINT);
+                SecurityCollection collection = new SecurityCollection();
+                collection.addPattern("/*");
+                securityConstraint.addCollection(collection);
+                context.addConstraint(securityConstraint);
+            }
+        };
+        tomcat.addAdditionalTomcatConnectors(redirectConnector());
+        return tomcat;
+    }
+
+    private Connector redirectConnector() {
+        Connector connector = new Connector(
+                TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
+        connector.setScheme(HTTP);
+        connector.setPort(HTTP_PORT);
+        connector.setSecure(false);
+        connector.setRedirectPort(HTTPS_PORT);
+        return connector;
+    }
+}

--- a/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
+++ b/Project-Matching/src/main/java/com/matching/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -38,8 +39,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
         http.cors().
                 and().
-                    csrf().
-                and().
+                    csrf().csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()).disable().
                     httpBasic().
                 and()
                     .authorizeRequests()
@@ -67,7 +67,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         configuration.addAllowedHeader(CorsConfiguration.ALL);
 
         configuration.setExposedHeaders(Arrays.asList("Access-Control-Allow-Headers", "Authorization, x-xsrf-token, Access-Control-Allow-Headers, Origin, Accept, X-Requested-With, " +
-                "Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers"));
+                "Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers" ));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/Project-Matching/src/main/java/com/matching/controller/ProfileController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/ProfileController.java
@@ -32,6 +32,7 @@ public class ProfileController {
         Resource<?> resource = profileService.findUserProfile(idx);
         resource.add(linkTo(methodOn(ProfileController.class).getProfile(idx, response)).withSelfRel());
         resource.add(linkTo(methodOn(ProfileController.class).getProfileSkills(idx, response)).withRel("Profile Skills"));
+        resource.add(linkTo(methodOn(ProfileController.class).getProfileMyProjects(idx, response)).withRel("My Projects"));
         resource.add(linkTo(methodOn(ProfileController.class).getProfileProjects(idx, response)).withRel("Processing Projects"));
         resource.add(linkTo(methodOn(ProfileController.class).getProfileDoneProjects(idx, response)).withRel("Done Projects"));
 
@@ -48,6 +49,20 @@ public class ProfileController {
 
         Resources<?> resources = profileService.getProfileSkills(idx, response);
         resources.add(linkTo(methodOn(ProfileController.class).getProfileSkills(idx, response)).withSelfRel());
+        return ResponseEntity.ok(resources);
+    }
+
+    @GetMapping(value = "/{idx}/myprojects", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getProfileMyProjects(@PathVariable Long idx, HttpServletResponse response) {
+        response.setHeader("Link", "<https://github.com/perfect-matching/perfectmatching-backend>; rel=\"profile\"");
+        response.setHeader("Location", "/api/profile/" + idx + "/myprojects");
+
+        if(profileService.findByProfileMyProjects(idx))
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        Resources<?> resources = profileService.getProfileMyProjects(idx);
+        resources.add(linkTo(methodOn(ProfileController.class).getProfileMyProjects(idx, response)).withSelfRel());
+
         return ResponseEntity.ok(resources);
     }
 

--- a/Project-Matching/src/main/java/com/matching/domain/dto/ProcessingProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/ProcessingProjectDTO.java
@@ -46,7 +46,7 @@ public class ProcessingProjectDTO {
     public ProcessingProjectDTO(UserProject userProject) {
         this.userIdx = userProject.getUser().getIdx();
         this.projectIdx = userProject.getProject().getIdx();
-        this.leaderNick = userProject.getUser().getNick();
+        this.leaderNick = userProject.getProject().getLeader().getNick();
         this.title = userProject.getProject().getTitle();
         this.status = userProject.getProject().getStatus().getStatus();
         this.createdDate = userProject.getProject().getCreatedDate();

--- a/Project-Matching/src/main/java/com/matching/domain/dto/ProjectApplyDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/ProjectApplyDTO.java
@@ -1,0 +1,28 @@
+package com.matching.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectApplyDTO {
+
+    @NotNull(message = "Project Idx가 비어있습니다.")
+    private Long projectIdx;
+
+    @NotBlank(message = "신청직군이 비어있습니다.")
+    @Length(max = 10)
+    private String position;
+
+    @NotBlank(message = "지원동기가 비어있습니다.")
+    @Length(max = 400)
+    private String simpleProfile;
+}

--- a/Project-Matching/src/main/java/com/matching/domain/enums/LocationType.java
+++ b/Project-Matching/src/main/java/com/matching/domain/enums/LocationType.java
@@ -21,7 +21,8 @@ public enum LocationType {
     JEOLLANAMDO("전라남도"),
     GYENONGSNAGBUKDO("경상북도"),
     GYENONGSANGNAMDO("경상남도"),
-    JEJUDO("제주도");
+    JEJUDO("제주도"),
+    ALL("모든 지역");
 
     private String location;
 

--- a/Project-Matching/src/main/java/com/matching/domain/enums/PositionType.java
+++ b/Project-Matching/src/main/java/com/matching/domain/enums/PositionType.java
@@ -24,4 +24,8 @@ public enum PositionType {
         Random random = new Random();
         return values()[random.nextInt(values().length)];
     }
+
+    public static PositionType getPosition(int index) {
+        return values()[index];
+    }
 }

--- a/Project-Matching/src/main/java/com/matching/repository/UserProjectRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/UserProjectRepository.java
@@ -10,12 +10,17 @@ import com.matching.domain.enums.UserProjectStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserProjectRepository extends JpaRepository<UserProject, UserProjectKey> {
 
+    UserProject findByUserAndProject(User user, Project project);
+
     Integer countByProjectAndPositionAndStatus(Project project, PositionType positionType, UserProjectStatus status);
 
-    List<UserProject> findByUserAndProject_StatusOrderByProjectDesc(User user, ProjectStatus status);
+    List<UserProject> findByUserAndStatusAndPositionOrderByProjectDesc(User user, UserProjectStatus status, PositionType positionType);
+
+    List<UserProject> findByUserAndProject_StatusAndStatusAndPositionNotOrderByProjectDesc(User user, ProjectStatus status, UserProjectStatus userProjectStatus, PositionType positionType);
 
     List<UserProject> findByProjectAndStatus(Project project, UserProjectStatus status);
 }

--- a/Project-Matching/src/main/java/com/matching/service/ProfileService.java
+++ b/Project-Matching/src/main/java/com/matching/service/ProfileService.java
@@ -9,7 +9,9 @@ import com.matching.domain.UserSkill;
 import com.matching.domain.dto.DoneProjectDTO;
 import com.matching.domain.dto.ProfileDTO;
 import com.matching.domain.dto.ProcessingProjectDTO;
+import com.matching.domain.enums.PositionType;
 import com.matching.domain.enums.ProjectStatus;
+import com.matching.domain.enums.UserProjectStatus;
 import com.matching.repository.DoneProjectRepository;
 import com.matching.repository.UserProjectRepository;
 import com.matching.repository.UserRepository;
@@ -76,15 +78,15 @@ public class ProfileService {
     public boolean findProfileProjects(Long idx) {
         if(userRepository.findByIdx(idx) == null)
             return  true;
-        return userProjectRepository.findByUserAndProject_StatusOrderByProjectDesc(userRepository.findByIdx(idx),
-                ProjectStatus.PROGRESS) == null;
+        return userProjectRepository.findByUserAndProject_StatusAndStatusAndPositionNotOrderByProjectDesc(userRepository.findByIdx(idx),
+                ProjectStatus.PROGRESS, UserProjectStatus.MATCHING, PositionType.LEADER) == null;
     }
 
     public Resources<?> getProfileProjects(Long idx) {
         User user = userRepository.findByIdx(idx);
         List<ProcessingProjectDTO> list = new ArrayList<>();
-        List<UserProject> userProjectList = userProjectRepository.findByUserAndProject_StatusOrderByProjectDesc(user,
-                ProjectStatus.PROGRESS);
+        List<UserProject> userProjectList = userProjectRepository.findByUserAndProject_StatusAndStatusAndPositionNotOrderByProjectDesc(user,
+                ProjectStatus.PROGRESS, UserProjectStatus.MATCHING, PositionType.LEADER);
 
         for(UserProject userProject : userProjectList) {
             list.add(new ProcessingProjectDTO(userProject));
@@ -111,5 +113,25 @@ public class ProfileService {
         }
 
         return new Resources<>(resourceList);
+    }
+
+    public boolean findByProfileMyProjects(Long idx) {
+        if(userRepository.findByIdx(idx) == null)
+            return  true;
+        return userProjectRepository.findByUserAndStatusAndPositionOrderByProjectDesc(userRepository.findByIdx(idx),
+                UserProjectStatus.MATCHING, PositionType.LEADER) == null;
+    }
+
+    public Resources<?> getProfileMyProjects(Long idx) {
+        User user = userRepository.findByIdx(idx);
+        List<ProcessingProjectDTO> list = new ArrayList<>();
+        List<UserProject> userProjectList = userProjectRepository.findByUserAndStatusAndPositionOrderByProjectDesc(user,
+                UserProjectStatus.MATCHING, PositionType.LEADER);
+
+        for(UserProject userProject : userProjectList) {
+            list.add(new ProcessingProjectDTO(userProject));
+        }
+
+        return new Resources<>(list);
     }
 }

--- a/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
@@ -69,6 +69,16 @@ public class ProfileControllerTest {
     }
 
     @Test
+    public void getProfileMyProjectsTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/myprojects").with(user("Test_User@gmail.com")
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(redirectedUrl("/api/profile/" + user.getIdx() + "/myprojects"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     public void getProfileProjectsTest() throws Exception {
         mockMvc.perform(get("/api/profile/" + user.getIdx() + "/projects").with(user("Test_User@gmail.com")
                 .password("test_password")))

--- a/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProjectControllerTest.java
@@ -3,6 +3,7 @@ package com.matching.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.matching.config.auth.SecurityConstants;
 import com.matching.domain.*;
+import com.matching.domain.dto.ProjectApplyDTO;
 import com.matching.domain.dto.ProjectDTO;
 import com.matching.domain.enums.LocationType;
 import com.matching.domain.enums.PositionType;
@@ -22,16 +23,14 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -255,6 +254,174 @@ public class ProjectControllerTest {
         mockMvc.perform(delete("/api/project/" + projectRepository.findByTitle("테스트 타이틀 12312321").getIdx()).header(SecurityConstants.TOKEN_HEADER, token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void putProjectStatusProgressTest() throws Exception {
+
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Long projectIdx = projectRepository.findByTitle("테스트 타이틀 12312321").getIdx();
+
+        mockMvc.perform(put("/api/project/" + projectIdx + "/status?status=PROGRESS" ).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    public void putProjectStatusCompleteTest() throws Exception {
+
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Long projectIdx = projectRepository.findByTitle("테스트 타이틀 12312321").getIdx();
+
+        mockMvc.perform(put("/api/project/" + projectIdx + "/status?status=COMPLETE" ).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+
+    }
+
+    @Test
+    public void postProjectApplyTest() throws Exception {
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Long projectIdx = projectRepository.findByTitle("테스트 타이틀 12312321").getIdx();
+
+        ProjectApplyDTO projectApplyDTO = ProjectApplyDTO.builder().projectIdx(projectIdx).position("디자이너").simpleProfile("지원 사유").build();
+
+        mockMvc.perform(post("/api/project/apply").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectApplyDTO)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void putProjectMatchingTest() throws Exception {
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Long projectIdx = projectRepository.findByTitle("테스트 타이틀 12312321").getIdx();
+
+        ProjectApplyDTO projectApplyDTO = ProjectApplyDTO.builder().projectIdx(projectIdx).position("디자이너").simpleProfile("지원 사유").build();
+
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        User user = User.builder().nick("Test User222").email("Test_User333@gmail.com").password(passwordEncoder.encode("test_password"))
+                .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
+                .investTime(4).socialUrl("https://github.com/testUser").build();
+
+        userRepository.save(user);
+
+        UserDetails userDetails2 = userService.loadUserByUsername(user.getEmail());
+
+        List<String> roles = userDetails.getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        String token2 = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, SecurityConstants.JWT_SECRET.getBytes())
+                .setHeaderParam("typ", SecurityConstants.TOKEN_TYPE)
+                .setIssuer(SecurityConstants.TOKEN_ISSUER)
+                .setAudience(SecurityConstants.TOKEN_AUDIENCE)
+                .setSubject("Perfect-Matching JWT Token")
+                .claim("idx", userRepository.findByEmail(user.getEmail()).getIdx())
+                .claim("email", user.getEmail())
+                .claim("nickname", user.getNick())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1800000))
+                .claim("role", roles)
+                .compact();
+
+
+        mockMvc.perform(post("/api/project/apply").header(SecurityConstants.TOKEN_HEADER, token2)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectApplyDTO)).with(user(userDetails2)))
+                .andExpect(status().isCreated());
+
+        Map<String, String> map = new HashMap<>();
+
+        map.put("projectIdx", String.valueOf(projectIdx));
+        map.put("userIdx", String.valueOf(user.getIdx()));
+        map.put("status", "매칭");
+
+        mockMvc.perform(put("/api/project/matching").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(map)).with(user(userDetails)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteProjectCancelTest() throws Exception {
+        Set<Tag> tag = new HashSet<>();
+
+        tag.add(Tag.builder().text("테스트 코드 태그 1").build());
+        tag.add(Tag.builder().text("테스트 코드 태그 2").build());
+
+        ProjectDTO projectdto = ProjectDTO.builder().title("테스트 타이틀 12312321").location("서울").summary("요로요러한 프로젝트")
+                .designerRecruits(1).developerRecruits(1).plannerRecruits(1).marketerRecruits(1).etcRecruits(1).tags(tag).build();
+
+        mockMvc.perform(post("/api/project").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectdto)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        Long projectIdx = projectRepository.findByTitle("테스트 타이틀 12312321").getIdx();
+
+        ProjectApplyDTO projectApplyDTO = ProjectApplyDTO.builder().projectIdx(projectIdx).position("디자이너").simpleProfile("지원 사유").build();
+
+        mockMvc.perform(post("/api/project/apply").header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(projectApplyDTO)).with(user(userDetails)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(delete("/api/project/cancel/" + projectIdx).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE).with(user(userDetails)))
                 .andExpect(status().isOk());
     }
 

--- a/Project-Matching/src/test/java/com/matching/domain/dto/ProjectApplyDTOTest.java
+++ b/Project-Matching/src/test/java/com/matching/domain/dto/ProjectApplyDTOTest.java
@@ -1,0 +1,16 @@
+package com.matching.domain.dto;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProjectApplyDTOTest {
+
+    @Test
+    public void createProjectApplyDTOTest() {
+        ProjectApplyDTO projectApplyDTO = new ProjectApplyDTO();
+
+        assertThat(projectApplyDTO).isNotNull();
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ Project - Side Project Member Matching Platform
     | `/api/usedskill/{idx}` | GET | idx에 따른 UsedSkill을 가져오기 위한 api |
     | `/api/tags` | GET | DB에 등록되어 있는 Tag들을 가져오기 위한 api |
     | `/api/userskills` | GET | DB에 등록되어 있는 UserSkill들을 가져오기 위한 api |
-    | `/api/usedskills` | GET | DB에 등록되어 있는 UsedSkill들을 가져오기 위한 api |
+    | `/api/usedskills` | GET | DB에 등록되어 있는 UsedSkill들을 가져오기 위한 api | 
+    | `/api/img/{fileName:.+}` | GET | 서버에 업로드되어 있는 이미지 파일을 가져오기 위한 api |
+    | `/api/profile/{idx}/myproject` | GET | 유저가 개설한 프로젝트를 가져오기 위한 api |
+    | `/api/project/{idx}/joinmembers` | GET | 프로젝트의 지원자 목록을 가져오기 위한 api | 
 
 * [POST]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/post.md )
 
@@ -156,19 +159,24 @@ Project - Side Project Member Matching Platform
     | `/api/register/nickcheck` | POST | User 생성을 위해 회원가입시 닉네임 중복 체크를 요청하는 api |
     | `/api/register/emailcheck` | POST | User 생성을 위해 회원가입시 이메일 중복 체크를 요청하는 api |
     | `/api/comment` | POST | Comment를 생성하기 위해 요청하는 api |
+    | `/project/apply` | POST | 유저가 프로젝트에 지원하기 위해 요청하는 api |
 
-* PUT( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/put.md )
+* [PUT]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/put.md )
 
     |URI(자원)| HTTP(행위) | 기능(표현) |
     |:---:|:---:|:---:|
     | `/api/project/{idx}` | PUT | Project의 idx에 따라 Project를 수정하기 위한 api |
     | `/api/comment/{idx}` | PUT | Comment의 idx에 따라 Comment를 수정하기 위한 api |
+    | `/api/img` | PUT | 유저의 프로필 사진을 변경하기 위한 api |
+    | `/project/{idx}/status?status={name}` | PUT | Project의 Status를 name에 따라 변경하기 위한 api |
+    | `/api/project/matching` | PUT | Project 개설자가 지원자를 매칭 또는 거절을 요청하기 위한 api |
 
-* DELETE( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/delete.md )
+* [DELETE]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/delete.md )
 
     |URI(자원)| HTTP(행위) | 기능(표현) |
     |:---:|:---:|:---:|
     | `/api/project/{idx}` | DELETE | Project의 idx에 따라 Projet를 삭제하기 위한 api |
     | `/api/comment/{idx}` | DELETE | Comment의 idx에 따라 Comment를 삭제하기 위한 api |
+    | `/api/img` | DELETE | User의 기존 프로필 이미지를 삭제하고 기본 이미지로 변경하기 위한 api |
 
 </details>

--- a/documents/delete.md
+++ b/documents/delete.md
@@ -6,7 +6,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 * `https://donghun-dev.kro.kr:8083/api/comment/{idx}`
 
@@ -14,4 +14,20 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
+
+* `https://donghun-dev.kro.kr:8083/api/project/cancel/{idx}`
+
+  * {idx} UserProject 삭제.
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+* `https://donghun-dev.kro.kr:8083/api/img`
+
+  * 유저의 기존 프로필 이미지를 삭제하고 기본 이미지로 변경.
+
+  * Success : Code 200
+
+  * Fail : Code 400

--- a/documents/get.md
+++ b/documents/get.md
@@ -6,7 +6,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -99,7 +99,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?location=SEOUL`
@@ -108,7 +108,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?location=SEOUL&offset=1`
@@ -117,7 +117,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER`
@@ -126,7 +126,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&offset=1`
@@ -135,7 +135,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&location=SEOUL`
@@ -144,7 +144,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/projects?position=DEVELOPER&location=SEOUL&offset=1`
@@ -153,7 +153,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
 
 * `https://donghun-dev.kro.kr:8083/api/project/1`
@@ -162,7 +162,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -232,7 +232,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -285,7 +285,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -319,7 +319,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -378,7 +378,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -413,7 +413,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -454,7 +454,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -497,7 +497,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -563,7 +563,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -590,7 +590,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -617,7 +617,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -658,7 +658,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -679,7 +679,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -700,7 +700,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -721,7 +721,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -762,7 +762,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -803,7 +803,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -843,4 +843,79 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
+
+* `https://donghun-dev.kro.kr:8083/api/profile/1/myprojects`
+
+  * 유저의 {idx}의 개설한 프로젝트의 정보들을 가져옴.
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+    "_embedded": {
+        "datas": [
+            {
+                "userIdx": 1,
+                "projectIdx": 134,
+                "leaderNick": "testUser_1",
+                "title": "이러 이러한 Side Project 의 함께할 사람들을 찾고 있습니다. 134",
+                "status": "진행중",
+                "createdDate": "2019-09-06T17:44:03",
+                "position": "기타",
+                "summary": "이러한 프로젝트에 참여할 인원을 모집합니다."
+            },
+            {
+                "userIdx": 1,
+                "projectIdx": 125,
+                "leaderNick": "testUser_1",
+                "title": "이러 이러한 Side Project 의 함께할 사람들을 찾고 있습니다. 125",
+                "status": "진행중",
+                "createdDate": "2019-09-06T17:44:03",
+                "position": "마케터",
+                "summary": "이러한 프로젝트에 참여할 인원을 모집합니다."
+            }
+        ]
+    },
+    "_links": {
+        "self": {
+            "href": "https://donghun-dev.kro.kr:8084/api/profile/1/projects"
+        }
+    }
+  }
+  ```
+
+* `https://donghun-dev.kro.kr:8083/api/project/1/joinmembers`
+
+  * 프로젝트 {idx}의 지원자들의 정보를 가져옴.
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+    "_embedded": {
+        "datas": [
+            {
+                "memberIdx": 22,
+                "projectIdx": 1,
+                "memberNick": "testUser_22",
+                "position": "마케터",
+                "_links": {
+                    "Profile": {
+                        "href": "https://donghun-dev.kro.kr:8084/api/profile/22"
+                    }
+                }
+            }
+        ]
+    },
+    "_links": {
+        "self": {
+            "href": "https://donghun-dev.kro.kr:8084/api/project/1/members"
+        }
+    }
+  }
+  ```

--- a/documents/post.md
+++ b/documents/post.md
@@ -4,9 +4,9 @@
 
   * POST Project JSON Form Data Example
 
-  * Success : Code 200
+  * Success : Code 201
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -55,9 +55,9 @@
 
   * SignUp JSON Form Data Example
 
-  * Success : Code 200
+  * Success : Code 201
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -88,7 +88,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -103,7 +103,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -116,13 +116,29 @@
 
   * POST Comment JSON Form Data Example
 
-  * Success : Code 200
+  * Success : Code 201
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
     "content" : "작성하고자 하는 댓글",
     "projectIdx" : 1
+  }
+  ```
+
+* `https://donghun-dev.kro.kr:8083/api/project/apply`
+
+  * POST Project Apply JSON Form Data Example
+
+  * Success : Code 201
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+  "projectIdx" : 1,
+  "position" : "개발자",
+  "simpleProfile" : "그냥 지원하게 되었습니다."
   }
   ```

--- a/documents/put.md
+++ b/documents/put.md
@@ -6,7 +6,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -40,7 +40,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   ```JSON
   {
@@ -55,7 +55,7 @@
 
   * Success : Code 200
 
-  * Fail : Code 403
+  * Fail : Code 400
 
   * Request Data(form-data)
   ```
@@ -71,5 +71,29 @@
       "fileDownloadUri": "http://localhost:8080/api/img/PROFILE_IMG_1568638730292.jpg",
       "fileType": "image/jpeg",
       "size": 6228
+  }
+  ```
+
+* `https://donghun-dev.kro.kr:8083/project/{idx}/status?status={name}`
+
+  * 프로젝트의 status를 변경하기 위한 api
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+* `https://donghun-dev.kro.kr:8083/api/project/matching`
+
+  * 프로젝트의 status를 변경하기 위한 api
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+  "projectIdx" : 1,
+  "userIdx" : 39,
+  "status" : "매칭"
   }
   ```


### PR DESCRIPTION
- 프로젝트 상세 변경 로직 작성. (#86)
- 프로젝트 매칭 관련 로직 작성. (#87)
- 프로젝트 리스트 쿼리 스트링 키워드 추가. (#89)
- 유저가 개설한 프로젝트를 볼 수 있는 API 추가.
- 프로제긑의 지원자를 볼 수 있는 API 추가.
- 프로젝트 매칭 관련 로직을 위한 `ProjectApplyDTO` 클래스 추가.
- 추가되는 로직들에 대한 테스트 코드들 작성.
- 추가된 로직들에 대한 REST API 명세 작성. (#10)