### PR TITLE
Added 프로젝트 지원자 목록 추가 및 Bug Fix.

### DIFF
--- a/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthenticationFilter.java
+++ b/Project-Matching/src/main/java/com/matching/config/filter/JwtAuthenticationFilter.java
@@ -93,7 +93,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                 .claim("email", user.getUsername())
                 .claim("nickname", userRepository.findByEmail(user.getUsername()).getNick())
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 3600000))
+                .setExpiration(new Date(System.currentTimeMillis() + 999999999999999999L))
                 .claim("role", roles)
                 .compact();
 

--- a/Project-Matching/src/main/java/com/matching/controller/ProfileController.java
+++ b/Project-Matching/src/main/java/com/matching/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.matching.controller;
 
 import com.matching.domain.docs.RestDocs;
+import com.matching.domain.dto.ProfileDTO;
 import com.matching.service.ProfileService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
@@ -8,11 +9,14 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
@@ -34,6 +38,7 @@ public class ProfileController {
         resource.add(linkTo(methodOn(ProfileController.class).getProfile(idx)).withSelfRel());
         resource.add(linkTo(methodOn(ProfileController.class).getProfileSkills(idx)).withRel("Profile Skills"));
         resource.add(linkTo(methodOn(ProfileController.class).getProfileMyProjects(idx)).withRel("My Projects"));
+        resource.add(linkTo(methodOn(ProfileController.class).getProfileApplyProjects(idx)).withRel("Apply Projects"));
         resource.add(linkTo(methodOn(ProfileController.class).getProfileProjects(idx)).withRel("Processing Projects"));
         resource.add(linkTo(methodOn(ProfileController.class).getProfileDoneProjects(idx)).withRel("Done Projects"));
 
@@ -67,6 +72,7 @@ public class ProfileController {
 
         URI uri = linkTo(methodOn(ProfileController.class).getProfileMyProjects(idx)).toUri();
         RestDocs restDocs = new RestDocs(uri);
+
         return new ResponseEntity<>(resources, restDocs.getHttpHeaders(), HttpStatus.OK);
     }
 
@@ -95,6 +101,46 @@ public class ProfileController {
 
         URI uri = linkTo(methodOn(ProfileController.class).getProfileDoneProjects(idx)).toUri();
         RestDocs restDocs = new RestDocs(uri);
+
         return new ResponseEntity<>(resources, restDocs.getHttpHeaders(), HttpStatus.OK);
     }
+
+    @GetMapping(value = "/{idx}/applyprojects", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> getProfileApplyProjects(@PathVariable Long idx) {
+
+        if(profileService.findProfileApplyProjects(idx))
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+        Resources<?> resources = profileService.getProfileApplyProjects(idx);
+        resources.add(linkTo(methodOn(ProfileController.class).getProfileApplyProjects(idx)).withSelfRel());
+
+        URI uri = linkTo(methodOn(ProfileController.class).getProfileApplyProjects(idx)).toUri();
+        RestDocs restDocs = new RestDocs(uri);
+
+        return new ResponseEntity<>(resources, restDocs.getHttpHeaders(), HttpStatus.OK);
+    }
+
+    @PostMapping("/modify/nickcheck")
+    public ResponseEntity<?> nickCheck(@RequestBody Map<String, String> nick, HttpServletRequest request) {
+        URI uri = linkTo(methodOn(RegisterController.class).nickCheck(nick)).toUri();
+        RestDocs restDocs = new RestDocs(uri);
+        return profileService.findUserNick(nick.get("nick"), request) ? new ResponseEntity<>("{\"message\": \"이미 사용중인 닉네임입니다.\"}", HttpStatus.BAD_REQUEST)
+                : new ResponseEntity<>("{\"message\": \"사용가능한 멋진 닉네임 입니다.\"}", restDocs.getHttpHeaders(), HttpStatus.OK);
+    }
+
+    @PutMapping("/{idx}")
+    public ResponseEntity<?> putProfile(@Valid @RequestBody ProfileDTO profileDTO, BindingResult result, @PathVariable Long idx,
+                                        HttpServletRequest request) {
+        if (result.hasErrors()) {
+            StringBuilder msg = profileService.validation(result);
+            return new ResponseEntity<>(msg.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        URI uri = linkTo(methodOn(ProfileController.class).putProfile(profileDTO, result, idx, request)).toUri();
+        RestDocs restDocs = new RestDocs(uri);
+
+        return  profileService.putProfile(profileDTO, request, idx, restDocs);
+    }
+
+
 }

--- a/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/DoneProjectDTO.java
@@ -54,7 +54,7 @@ public class DoneProjectDTO {
 
     private String socialUrl;
 
-    private Set<UsedSkill> usedSkills = new HashSet<>();
+    private Set<UsedSkill> tags = new HashSet<>();
 
     public DoneProjectDTO(DoneProject doneProject) {
         this.doneProjectIdx = doneProject.getIdx();
@@ -69,6 +69,6 @@ public class DoneProjectDTO {
         this.startDate = doneProject.getStartDate();
         this.endDate = doneProject.getEndDate();
         this.socialUrl = doneProject.getSocialUrl();
-        this.usedSkills.addAll(doneProject.getUsedSkills());
+        this.tags.addAll(doneProject.getUsedSkills());
     }
 }

--- a/Project-Matching/src/main/java/com/matching/domain/dto/ProfileDTO.java
+++ b/Project-Matching/src/main/java/com/matching/domain/dto/ProfileDTO.java
@@ -1,6 +1,7 @@
 package com.matching.domain.dto;
 
 import com.matching.domain.User;
+import com.matching.domain.UserSkill;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,6 +10,9 @@ import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.HashSet;
+import java.util.Set;
 
 @Data
 @Builder
@@ -26,6 +30,8 @@ public class ProfileDTO {
     @Length(max = 500)
     private String summary;
 
+    @NotBlank
+    @Length(max = 100)
     private String profileImage;
 
     @NotBlank
@@ -33,15 +39,13 @@ public class ProfileDTO {
     @Length(max = 30, min = 3)
     private String email;
 
-    @NotBlank
-    @Length(max = 100)
-    private String profileImg;
-
-    @NotBlank
+    @NotNull
     private Integer investTime;
 
     @Length(max = 100)
     private String socialUrl;
+
+    private Set<UserSkill> userSkills = new HashSet<>();
 
     public ProfileDTO(User user) {
         this.userIdx = user.getIdx();
@@ -49,7 +53,6 @@ public class ProfileDTO {
         this.summary = user.getDescription();
         this.profileImage = user.getProfileImg();
         this.email = user.getEmail();
-        this.profileImg = user.getProfileImg();
         this.investTime = user.getInvestTime();
         this.socialUrl = user.getSocialUrl();
     }

--- a/Project-Matching/src/main/java/com/matching/repository/UserProjectRepository.java
+++ b/Project-Matching/src/main/java/com/matching/repository/UserProjectRepository.java
@@ -10,7 +10,6 @@ import com.matching.domain.enums.UserProjectStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface UserProjectRepository extends JpaRepository<UserProject, UserProjectKey> {
 
@@ -22,5 +21,8 @@ public interface UserProjectRepository extends JpaRepository<UserProject, UserPr
 
     List<UserProject> findByUserAndProject_StatusAndStatusAndPositionNotOrderByProjectDesc(User user, ProjectStatus status, UserProjectStatus userProjectStatus, PositionType positionType);
 
+    List<UserProject> findByUserAndStatusAndPositionNotOrderByProjectDesc(User user, UserProjectStatus userProjectStatus, PositionType positionType);
+
     List<UserProject> findByProjectAndStatus(Project project, UserProjectStatus status);
+
 }

--- a/Project-Matching/src/main/java/com/matching/service/DoneProjectService.java
+++ b/Project-Matching/src/main/java/com/matching/service/DoneProjectService.java
@@ -87,7 +87,7 @@ public class DoneProjectService {
         user.addDoneProject(doneProject);
         doneProjectRepository.save(doneProject);
 
-        for(UsedSkill usedSkill : doneProjectDTO.getUsedSkills()) {
+        for(UsedSkill usedSkill : doneProjectDTO.getTags()) {
             doneProject.addUsedSkill(usedSkill);
             usedSkillRepository.save(usedSkill);
         }
@@ -114,7 +114,7 @@ public class DoneProjectService {
         doneProject.getUsedSkills().clear();
         doneProjectRepository.save(doneProject);
 
-        for(UsedSkill usedSkill : doneProjectDTO.getUsedSkills()) {
+        for(UsedSkill usedSkill : doneProjectDTO.getTags()) {
             doneProject.addUsedSkill(usedSkill);
             usedSkillRepository.save(usedSkill);
         }

--- a/Project-Matching/src/main/java/com/matching/service/ProfileService.java
+++ b/Project-Matching/src/main/java/com/matching/service/ProfileService.java
@@ -1,14 +1,17 @@
 package com.matching.service;
 
+import com.matching.config.auth.JwtResolver;
 import com.matching.controller.DoneProjectController;
 import com.matching.controller.TagController;
 import com.matching.domain.DoneProject;
 import com.matching.domain.User;
 import com.matching.domain.UserProject;
 import com.matching.domain.UserSkill;
+import com.matching.domain.docs.RestDocs;
 import com.matching.domain.dto.DoneProjectDTO;
 import com.matching.domain.dto.ProfileDTO;
 import com.matching.domain.dto.ProcessingProjectDTO;
+import com.matching.domain.dto.UserDTO;
 import com.matching.domain.enums.PositionType;
 import com.matching.domain.enums.ProjectStatus;
 import com.matching.domain.enums.UserProjectStatus;
@@ -16,12 +19,20 @@ import com.matching.repository.DoneProjectRepository;
 import com.matching.repository.UserProjectRepository;
 import com.matching.repository.UserRepository;
 import com.matching.repository.UserSkillRepository;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -134,4 +145,71 @@ public class ProfileService {
 
         return new Resources<>(list);
     }
+
+    public boolean findUserNick(String nick, HttpServletRequest request) {
+        JwtResolver jwtResolver = new JwtResolver(request);
+        User user = userRepository.findByEmail(jwtResolver.getUserByToken());
+
+        String currentNick = user.getNick();
+
+        if(userRepository.findByNick(nick) != null && currentNick.equals(nick))
+            return false;
+        else if(userRepository.findByNick(nick) != null && !currentNick.equals(nick))
+            return true;
+        else
+            return false;
+    }
+
+    public StringBuilder validation(BindingResult bindingResult) {
+        List<ObjectError> list = bindingResult.getAllErrors();
+        StringBuilder msg = new StringBuilder();
+        for (ObjectError error : list)
+            msg.append(error.getDefaultMessage()).append("\n");
+        return msg;
+    }
+
+    public ResponseEntity<?> putProfile(@Valid ProfileDTO profileDTO, HttpServletRequest request, Long idx, RestDocs restDocs) {
+        JwtResolver jwtResolver = new JwtResolver(request);
+        User user = userRepository.findByEmail(jwtResolver.getUserByToken());
+
+        if(!user.getIdx().equals(idx)) {
+            return new ResponseEntity<>("{\"message\": \"잘못된 요청입니다.\"}", restDocs.getHttpHeaders(),HttpStatus.BAD_REQUEST);
+        }
+
+        user.setNick(profileDTO.getNickname());
+        user.setDescription(profileDTO.getSummary());
+        user.setSocialUrl(profileDTO.getSocialUrl());
+        user.setInvestTime(profileDTO.getInvestTime());
+
+        userRepository.save(user);
+
+        for(UserSkill userSkill : profileDTO.getUserSkills()) {
+            user.addUserSkill(userSkill);
+            userSkillRepository.save(userSkill);
+        }
+
+        return new ResponseEntity<>("{}", restDocs.getHttpHeaders(),HttpStatus.OK);
+
+    }
+
+    public boolean findProfileApplyProjects(Long idx) {
+        if(userRepository.findByIdx(idx) == null)
+            return  true;
+        return userProjectRepository.findByUserAndStatusAndPositionNotOrderByProjectDesc(userRepository.findByIdx(idx),
+                UserProjectStatus.WAIT, PositionType.LEADER) == null;
+    }
+
+    public Resources<?> getProfileApplyProjects(Long idx) {
+        User user = userRepository.findByIdx(idx);
+        List<ProcessingProjectDTO> list = new ArrayList<>();
+        List<UserProject> userProjectList = userProjectRepository.findByUserAndStatusAndPositionNotOrderByProjectDesc(user, UserProjectStatus.WAIT,
+                PositionType.LEADER);
+
+        for(UserProject userProject : userProjectList) {
+            list.add(new ProcessingProjectDTO(userProject));
+        }
+
+        return new Resources<>(list);
+    }
+
 }

--- a/Project-Matching/src/test/java/com/matching/controller/DoneProjectControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/DoneProjectControllerTest.java
@@ -132,7 +132,7 @@ public class DoneProjectControllerTest {
         usedSkills.add(UsedSkill.builder().text("Spring").build());
 
         DoneProjectDTO doneProjectDTO = DoneProjectDTO.builder().title("돈 프로젝트 테스트 타이틀").summary("테스트").content("타이틀")
-                .usedSkills(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
+                .tags(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
 
         mockMvc.perform(post("/api/doneproject").header(SecurityConstants.TOKEN_HEADER, token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -150,7 +150,7 @@ public class DoneProjectControllerTest {
         usedSkills.add(UsedSkill.builder().text("Spring").build());
 
         DoneProjectDTO doneProjectDTO = DoneProjectDTO.builder().title("돈 프로젝트 테스트 타이틀").summary("테스트").content("타이틀")
-                .usedSkills(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
+                .tags(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
 
         mockMvc.perform(post("/api/doneproject").header(SecurityConstants.TOKEN_HEADER, token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -167,7 +167,7 @@ public class DoneProjectControllerTest {
         usedSkills.remove(UsedSkill.builder().text("Spring").build());
         usedSkills.add(UsedSkill.builder().text("Python").build());
 
-        doneProjectDTO.setUsedSkills(usedSkills);
+        doneProjectDTO.setTags(usedSkills);
 
         Long doneProjectIdx = doneProjectRepository.findByTitle("돈 프로젝트 테스트 타이틀").getIdx();
 
@@ -186,7 +186,7 @@ public class DoneProjectControllerTest {
         usedSkills.add(UsedSkill.builder().text("Spring").build());
 
         DoneProjectDTO doneProjectDTO = DoneProjectDTO.builder().title("돈 프로젝트 테스트 타이틀").summary("테스트").content("타이틀")
-                .usedSkills(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
+                .tags(usedSkills).startDate(LocalDateTime.now()).endDate(LocalDateTime.now()).socialUrl("Github").build();
 
         mockMvc.perform(post("/api/doneproject").header(SecurityConstants.TOKEN_HEADER, token)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
+++ b/Project-Matching/src/test/java/com/matching/controller/ProfileControllerTest.java
@@ -1,23 +1,36 @@
 package com.matching.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matching.config.auth.SecurityConstants;
 import com.matching.domain.User;
+import com.matching.domain.UserSkill;
+import com.matching.domain.dto.ProfileDTO;
 import com.matching.repository.UserRepository;
+import com.matching.service.UserService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -25,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 public class ProfileControllerTest {
 
+    public static final String TEST_EMAIL = "Test_User@gmail.com";
     @Autowired
     private WebApplicationContext context;
 
@@ -35,22 +49,51 @@ public class ProfileControllerTest {
 
     private User user;
 
+    @Autowired
+    private UserService userService;
+
+    private UserDetails userDetails;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String token;
+
     @Before
     public void setMockMvc() {
         mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .alwaysDo(print())
                 .build();
 
-        user = User.builder().nick("Test User").email("Test_User@gmail.com").password("test_password")
+        user = User.builder().nick("Test User").email(TEST_EMAIL).password("test_password")
                 .profileImg("image..").description("test desc..").createdDate(LocalDateTime.now())
                 .investTime(4).socialUrl("https://github.com/testUser").build();
 
         userRepository.save(user);
+
+        userDetails = userService.loadUserByUsername(user.getEmail());
+        List<String> roles = userDetails.getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+        token = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, SecurityConstants.JWT_SECRET.getBytes())
+                .setHeaderParam("typ", SecurityConstants.TOKEN_TYPE)
+                .setIssuer(SecurityConstants.TOKEN_ISSUER)
+                .setAudience(SecurityConstants.TOKEN_AUDIENCE)
+                .setSubject("Perfect-Matching JWT Token")
+                .claim("idx", userRepository.findByEmail(user.getEmail()).getIdx())
+                .claim("email", user.getEmail())
+                .claim("nickname", user.getNick())
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1800000))
+                .claim("role", roles)
+                .compact();
     }
 
     @Test
     public void getProfileTest() throws Exception {
-        mockMvc.perform(get("/api/profile/" + user.getIdx()).with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/profile/" + user.getIdx()).with(user(TEST_EMAIL)
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
@@ -61,7 +104,7 @@ public class ProfileControllerTest {
 
     @Test
     public void getProfileSkillsTest() throws Exception {
-        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/skills").with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/skills").with(user(TEST_EMAIL)
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
@@ -71,7 +114,7 @@ public class ProfileControllerTest {
 
     @Test
     public void getProfileMyProjectsTest() throws Exception {
-        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/myprojects").with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/myprojects").with(user(TEST_EMAIL)
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
@@ -82,7 +125,7 @@ public class ProfileControllerTest {
 
     @Test
     public void getProfileProjectsTest() throws Exception {
-        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/projects").with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/projects").with(user(TEST_EMAIL)
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
@@ -93,10 +136,41 @@ public class ProfileControllerTest {
 
     @Test
     public void getProfileDoneProjectsTest() throws Exception {
-        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/doneprojects").with(user("Test_User@gmail.com")
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/doneprojects").with(user(TEST_EMAIL)
                 .password("test_password")))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
                 .andExpect(content().encoding("UTF-8"))
+                .andExpect(header().exists("Location"))
+                .andExpect(header().exists("Link"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getProfileApplyProjectsTest() throws Exception {
+        mockMvc.perform(get("/api/profile/" + user.getIdx() + "/applyprojects").with(user(TEST_EMAIL)
+                .password("test_password")))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(header().exists("Location"))
+                .andExpect(header().exists("Link"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void putProfileTest() throws Exception {
+        User user = userRepository.findByEmail(TEST_EMAIL);
+
+        Set<UserSkill> set = new HashSet<>();
+
+        set.add(UserSkill.builder().text("Java").build());
+        set.add(UserSkill.builder().text("Node.js").build());
+
+        ProfileDTO profileDTO = ProfileDTO.builder().nickname("테스트 닉네임").summary("테스트 소개").socialUrl("테스트 소셜").profileImage("테스트 이미지")
+                .investTime(5).userSkills(set).email("testuser@email.com").build();
+
+        mockMvc.perform(put("/api/profile/" + user.getIdx()).header(SecurityConstants.TOKEN_HEADER, token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(profileDTO)).with(user(userDetails)))
                 .andExpect(header().exists("Location"))
                 .andExpect(header().exists("Link"))
                 .andExpect(status().isOk());

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Project - Side Project Member Matching Platform
     | `/api/usedskills` | GET | DB에 등록되어 있는 UsedSkill들을 가져오기 위한 api | 
     | `/api/img/{fileName:.+}` | GET | 서버에 업로드되어 있는 이미지 파일을 가져오기 위한 api |
     | `/api/profile/{idx}/myprojects` | GET | 유저가 개설한 프로젝트를 가져오기 위한 api |
+    | `/api/profile/{idx}/applyprojects` | GET | 유저가 지원한 프로젝트를 가져오기 위한 api |
     | `/api/project/{idx}/joinmembers` | GET | 프로젝트의 지원자 목록을 가져오기 위한 api | 
 
 * [POST]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/post.md )
@@ -160,7 +161,9 @@ Project - Side Project Member Matching Platform
     | `/api/register/emailcheck` | POST | User 생성을 위해 회원가입시 이메일 중복 체크를 요청하는 api |
     | `/api/comment` | POST | Comment를 생성하기 위해 요청하는 api |
     | `/api/project/apply` | POST | 유저가 프로젝트에 지원하기 위해 요청하는 api |
-    | `/api/doneproject` | POST | DoneProject를 생성하기 위해 요청하는 api |
+    | `/api/doneproject` | POST | DoneProject를 생성하기 위해 요청하는 api | 
+    | `/api/modify/nickcheck` | POST | User 정보 수정시에 닉네임 중복 체크를 요청하는 api | 
+
 
 * [PUT]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/put.md )
 
@@ -172,6 +175,7 @@ Project - Side Project Member Matching Platform
     | `/api/project/{idx}/status?status={name}` | PUT | Project의 Status를 name에 따라 변경하기 위한 api |
     | `/api/project/matching` | PUT | Project 개설자가 지원자를 매칭 또는 거절을 요청하기 위한 api |
     | `/api/doneproject/{idx}` | PUT | DoneProject의 idx에 따라 DoneProject를 수정하기 위한 api |
+    | `/api/profile/{idx}` | PUT | User의 idx에 따라 Profile을 수정하기 위한 api | 
 
 * [DELETE]( https://github.com/perfect-matching/perfectmatching-backend/blob/master/documents/delete.md )
 

--- a/documents/get.md
+++ b/documents/get.md
@@ -919,3 +919,36 @@
     }
   }
   ```
+
+* `https://donghun-dev.kro.kr:8083/api/profile/{idx}/applyprojects`
+
+  * User {idx}의 지원한 프로젝트들의 정보를 가져옴.
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+    "_embedded": {
+        "datas": [
+            {
+                "userIdx": 1,
+                "projectIdx": 84,
+                "leaderNick": "testUser_3",
+                "profileImage": "https://donghun-dev.kro.kr:8083/api/image/USER_DEFAULT_PROFILE_IMG.png",
+                "title": "이러 이러한 Side Project 의 함께할 사람들을 찾고 있습니다. 84",
+                "status": "모집중",
+                "createdDate": "2019-09-19T23:09:27",
+                "position": "개발자",
+                "summary": "이러한 프로젝트에 참여할 인원을 모집합니다."
+            }
+        ]
+    },
+    "_links": {
+        "self": {
+            "href": "https://donghun-dev.kro.kr:8084/api/profile/1/applyprojects"
+        }
+    }
+    }
+  ```

--- a/documents/post.md
+++ b/documents/post.md
@@ -169,3 +169,17 @@
      ]
   }
   ```
+
+* `https://donghun-dev.kro.kr:8083/api/profile/modify/nickcheck`
+
+  * 회원정보 수정 닉네임 중복 체크 api form example
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {
+    "nick" : "admin"
+  }
+  ```

--- a/documents/put.md
+++ b/documents/put.md
@@ -119,3 +119,30 @@
      ]
   }
   ```
+
+* `https://donghun-dev.kro.kr:8083/api/profile/{idx}`
+
+  * {idx} User 수정.
+
+  * Success : Code 200
+
+  * Fail : Code 400
+
+  ```JSON
+  {     
+      "email": "testuser@gmail.com",
+      "nickname": "테스트 유저",
+      "summary": "~ 이러한 사람입니다.",
+      "socialUrl": "https://github.com/testUser/testProject",
+      "profileImage": "프로필 이미지",
+      "investTime": 5,
+      "userSkills" : [
+        {
+              "text": "JAVA"
+        },
+        {
+              "text": "Spring"
+        }
+     ]
+  }
+  ```


### PR DESCRIPTION
- 유저의 프로필에서 유저가 지원한 프로젝트의 목록도 볼 수 있도록 로직 추가. (#101)
- 프로젝트 진행 로직 오류 해결. (#100)
- 프로젝트 개설 로직 오류 해결. (#99)
- JWT 토큰 만료시간 최대로 증가. -> 개발 단계에서 원할한 테스트를 위해서 증가.
- 프로필 수정 페이지에서 닉네임 체크를 하는 로직 추가. -> 회원가입 떄 사용하는 닉네임 체크 로직을 사용할 경우 본인이 사용중인 닉네임도 이미 존재하는 닉네임이라고 뜨는 버그가 있어서 따로 로직 추가.
- 유저 정보를 수정할 수 있는 로직 추가.
- 클라이언트 컴포넌트 통일성을 위해 DoneProjectDTO의 usedSkills 필드를 tags로 네임 변경.
- 추가된 로직들에 대한 테스트 코드 추가.
- 추가된 로직들에 대한 REST API 명세 추가. (#10)